### PR TITLE
[Extension] Remove duplicated URL check in sw.ts

### DIFF
--- a/diagnostics-extension/src/sw.ts
+++ b/diagnostics-extension/src/sw.ts
@@ -23,14 +23,6 @@ chrome.runtime.onInstalled.addListener(
 );
 
 chrome.runtime.onMessageExternal.addListener((req: Request, sender, res) => {
-  // check if the senders origin contains the `cros-sample-telemetry-extension`
-  // path and block the request if not.
-  const path = "googlechromelabs.github.io/cros-sample-telemetry-extension";
-  if (!sender.url?.startsWith(path)) {
-    console.log("This PWA is not allowed to access the extension");
-    return;
-  }
-
   console.log(req, sender);
   switch (req.type) {
     case RequestType.TELEMETRY:


### PR DESCRIPTION
Since the "externally_connectable" value in file "manifest.json" has already checked whether the URL matches, the URL check in file "sw.ts" is not necessary.

BUG: b/296520125