### PR TITLE
Remove unsupported Telemetry service

### DIFF
--- a/common/dpsl.ts
+++ b/common/dpsl.ts
@@ -7,20 +7,6 @@
  */
 
 /**
- * Response message containing Backlight Info
- */
-export interface BacklightInfoObject {
-  path: string;
-  maxBrightness: number;
-  brightness: number;
-}
-
-/**
- * Response message containing Backlight Info
- */
-export type BacklightInfo = BacklightInfoObject[];
-
-/**
  * Response message containing Battery Info
  */
 export interface BatteryInfo {
@@ -39,21 +25,6 @@ export interface BatteryInfo {
   manufactureDate: string;
   temperature: string;
 }
-
-/**
- * Response message containing Bluetooth Info
- */
-export interface BluetoothInfoObject {
-  name: string;
-  address: string;
-  powered: boolean;
-  numConnectedDevices: number;
-}
-
-/**
- * Response message containing Bluetooth Info
- */
-export type BluetoothInfo = BluetoothInfoObject[];
 
 /**
  * Response message containing VPD Info
@@ -112,18 +83,6 @@ export interface CpuInfo {
 }
 
 /**
- * Response message containing individual Fan Info
- */
-export interface FanInfoObject {
-  speedRpm: number;
-}
-
-/**
- * Response message containing individual Fan Info
- */
-export type FanInfo = FanInfoObject[];
-
-/**
  * Response message containing Memory Info
  */
 export interface MemoryInfo {
@@ -169,14 +128,6 @@ export type BlockDeviceInfo = BlockDeviceInfoObject[];
 export interface StatefulPartitionInfo {
   availableSpace: string;
   totalSpace: string;
-}
-
-/**
- * Response message containing Timezone Info
- */
-export interface TimezoneInfo {
-  posix: string;
-  region: string;
 }
 
 // dpsl.diagnostics.* type definitions
@@ -254,16 +205,12 @@ export interface DiskReadRoutineParams {
 }
 
 export type DpslTypes =
-  | BacklightInfo
   | BatteryInfo
-  | BluetoothInfo
   | VpdInfo
   | CpuInfo
-  | FanInfo
   | MemoryInfo
   | BlockDeviceInfo
   | StatefulPartitionInfo
-  | TimezoneInfo;
 
 export type DiagnosticsParams =
   | BatteryChargeRoutineParams

--- a/common/message.ts
+++ b/common/message.ts
@@ -16,15 +16,11 @@ export const enum RequestType {
 }
 
 export const enum TelemetryInfoType {
-  BACKLIGHT = 'backlight',
   BATTERY = 'battery',
   BLOCK_DEVICE = 'block-device',
-  BLUETOOTH = 'bluetooth',
   CPU = 'cpu',
-  FAN = 'fan',
   MEMORY = 'memory',
   STATEFUL_PARTITION = 'stateful-partition',
-  TIMEZONE = 'timezone',
   VPD = 'vpd',
 }
 

--- a/diagnostics-app/src/app/core/services/telemetry.service.ts
+++ b/diagnostics-app/src/app/core/services/telemetry.service.ts
@@ -9,16 +9,12 @@
 import { Injectable } from '@angular/core';
 import { environment } from 'src/environments/environment';
 import {
-  BacklightInfo,
   BatteryInfo,
   BlockDeviceInfo,
-  BluetoothInfo,
   CpuInfo,
   DpslTypes,
-  FanInfo,
   MemoryInfo,
   StatefulPartitionInfo,
-  TimezoneInfo,
   VpdInfo,
 } from '@common/dpsl';
 import {
@@ -29,15 +25,11 @@ import {
 } from '@common/message';
 
 export interface TelemetryInterface {
-  fetchBacklightInfo(): Promise<BacklightInfo>;
   fetchBatteryInfo(): Promise<BatteryInfo>;
   fetchBlockDeviceInfo(): Promise<BlockDeviceInfo>;
-  fetchBluetoothInfo(): Promise<BluetoothInfo>;
   fetchCpuInfo(): Promise<CpuInfo>;
-  fetchFanInfo(): Promise<FanInfo>;
   fetchMemoryInfo(): Promise<MemoryInfo>;
   fetchStatefulPartitionInfo(): Promise<StatefulPartitionInfo>;
-  fetchTimezoneInfo(): Promise<TimezoneInfo>;
   fetchVpdInfo(): Promise<VpdInfo>;
 }
 
@@ -83,12 +75,6 @@ export class TelemetryService implements TelemetryInterface {
     this.extensionId = environment.extensionId;
   }
 
-  fetchBacklightInfo() {
-    return <Promise<BacklightInfo>>(
-      this.fetchTelemetryData(TelemetryInfoType.BACKLIGHT)
-    );
-  }
-
   fetchBatteryInfo() {
     return <Promise<BatteryInfo>>(
       this.fetchTelemetryData(TelemetryInfoType.BATTERY)
@@ -101,18 +87,8 @@ export class TelemetryService implements TelemetryInterface {
     );
   }
 
-  fetchBluetoothInfo() {
-    return <Promise<BluetoothInfo>>(
-      this.fetchTelemetryData(TelemetryInfoType.BLUETOOTH)
-    );
-  }
-
   fetchCpuInfo() {
     return <Promise<CpuInfo>>this.fetchTelemetryData(TelemetryInfoType.CPU);
-  }
-
-  fetchFanInfo() {
-    return <Promise<FanInfo>>this.fetchTelemetryData(TelemetryInfoType.FAN);
   }
 
   fetchMemoryInfo() {
@@ -124,12 +100,6 @@ export class TelemetryService implements TelemetryInterface {
   fetchStatefulPartitionInfo() {
     return <Promise<StatefulPartitionInfo>>(
       this.fetchTelemetryData(TelemetryInfoType.STATEFUL_PARTITION)
-    );
-  }
-
-  fetchTimezoneInfo() {
-    return <Promise<TimezoneInfo>>(
-      this.fetchTelemetryData(TelemetryInfoType.TIMEZONE)
     );
   }
 

--- a/diagnostics-extension/src/__tests__/controllers/telemetry.spec.ts
+++ b/diagnostics-extension/src/__tests__/controllers/telemetry.spec.ts
@@ -80,19 +80,9 @@ describe('should return correct telemetry data', () => {
     expectedResult: DpslTypes;
   }[] = [
     {
-      name: `backlight`,
-      infoType: TelemetryInfoType.BACKLIGHT,
-      expectedResult: fakeData.backlightInfo(),
-    },
-    {
       name: `battery`,
       infoType: TelemetryInfoType.BATTERY,
       expectedResult: fakeData.batteryInfo(),
-    },
-    {
-      name: `bluetooth`,
-      infoType: TelemetryInfoType.BLUETOOTH,
-      expectedResult: fakeData.bluetoothInfo(),
     },
     {
       name: `vpd`,
@@ -103,11 +93,6 @@ describe('should return correct telemetry data', () => {
       name: `cpu`,
       infoType: TelemetryInfoType.CPU,
       expectedResult: fakeData.cpuInfo(),
-    },
-    {
-      name: `fan`,
-      infoType: TelemetryInfoType.FAN,
-      expectedResult: fakeData.fanInfo(),
     },
     {
       name: `memory`,
@@ -123,11 +108,6 @@ describe('should return correct telemetry data', () => {
       name: `stateful partition`,
       infoType: TelemetryInfoType.STATEFUL_PARTITION,
       expectedResult: fakeData.statefulPartitionInfo(),
-    },
-    {
-      name: `timezone`,
-      infoType: TelemetryInfoType.TIMEZONE,
-      expectedResult: fakeData.timezoneInfo(),
     },
   ];
 

--- a/diagnostics-extension/src/__tests__/services/telemetry.spec.ts
+++ b/diagnostics-extension/src/__tests__/services/telemetry.spec.ts
@@ -33,19 +33,9 @@ describe('should return instance of FakeTelemetryService', () => {
     expectedResult: DpslTypes;
   }[] = [
     {
-      name: `backlight`,
-      methodUnderTest: telemetryService.getBacklightInfo,
-      expectedResult: fakeData.backlightInfo(),
-    },
-    {
       name: `battery`,
       methodUnderTest: telemetryService.getBatteryInfo,
       expectedResult: fakeData.batteryInfo(),
-    },
-    {
-      name: `bluetooth`,
-      methodUnderTest: telemetryService.getBluetoothInfo,
-      expectedResult: fakeData.bluetoothInfo(),
     },
     {
       name: `vpd`,
@@ -56,11 +46,6 @@ describe('should return instance of FakeTelemetryService', () => {
       name: `cpu`,
       methodUnderTest: telemetryService.getCpuInfo,
       expectedResult: fakeData.cpuInfo(),
-    },
-    {
-      name: `fan`,
-      methodUnderTest: telemetryService.getFanInfo,
-      expectedResult: fakeData.fanInfo(),
     },
     {
       name: `memory`,
@@ -76,11 +61,6 @@ describe('should return instance of FakeTelemetryService', () => {
       name: `stateful partition`,
       methodUnderTest: telemetryService.getStatefulPartitionInfo,
       expectedResult: fakeData.statefulPartitionInfo(),
-    },
-    {
-      name: `timezone`,
-      methodUnderTest: telemetryService.getTimezoneInfo,
-      expectedResult: fakeData.timezoneInfo(),
     },
   ];
 

--- a/diagnostics-extension/src/__tests__/utils.spec.ts
+++ b/diagnostics-extension/src/__tests__/utils.spec.ts
@@ -11,7 +11,7 @@ import {
   generateTelemetrySuccessResponse,
 } from '../utils';
 import { Response, TelemetryResponse } from '@common/message';
-import { backlightInfo } from '../services/fake_telemetry.data';
+import { batteryInfo } from '../services/fake_telemetry.data';
 
 describe('should generate correct response objects', () => {
   it('should generate correct error object', () => {
@@ -26,7 +26,7 @@ describe('should generate correct response objects', () => {
   });
 
   it('should generate correct telemetry response object', () => {
-    const payload: TelemetryResponse = { info: backlightInfo() };
+    const payload: TelemetryResponse = { info: batteryInfo() };
     const response: Response = generateTelemetrySuccessResponse(payload);
     expect(response).toEqual({
       success: true,

--- a/diagnostics-extension/src/controllers/telemetry.ts
+++ b/diagnostics-extension/src/controllers/telemetry.ts
@@ -28,24 +28,16 @@ const telemetryService = TelemetryServiceProvider.getTelemetryService();
 
 const mapInfoTypeToMethod = (infoType: TelemetryInfoType) => {
   switch (infoType) {
-    case TelemetryInfoType.BACKLIGHT:
-      return telemetryService.getBacklightInfo;
     case TelemetryInfoType.BATTERY:
       return telemetryService.getBatteryInfo;
     case TelemetryInfoType.BLOCK_DEVICE:
       return telemetryService.getNonRemovableBlockDevicesInfo;
-    case TelemetryInfoType.BLUETOOTH:
-      return telemetryService.getBluetoothInfo;
     case TelemetryInfoType.CPU:
       return telemetryService.getCpuInfo;
-    case TelemetryInfoType.FAN:
-      return telemetryService.getFanInfo;
     case TelemetryInfoType.MEMORY:
       return telemetryService.getMemoryInfo;
     case TelemetryInfoType.STATEFUL_PARTITION:
       return telemetryService.getStatefulPartitionInfo;
-    case TelemetryInfoType.TIMEZONE:
-      return telemetryService.getTimezoneInfo;
     case TelemetryInfoType.VPD:
       return telemetryService.getCachedVpdInfo;
     default:

--- a/diagnostics-extension/src/services/fake_telemetry.data.ts
+++ b/diagnostics-extension/src/services/fake_telemetry.data.ts
@@ -7,57 +7,21 @@
  */
 
 import {
-  BacklightInfo,
   BatteryInfo,
   BlockDeviceInfo,
-  BluetoothInfo,
   CpuArchitectureEnum,
   CpuInfo,
-  FanInfo,
   MemoryInfo,
   OemData,
   StatefulPartitionInfo,
-  TimezoneInfo,
   VpdInfo,
 } from '@common/dpsl';
-
-export const backlightInfo = (): BacklightInfo => [
-  {
-    brightness: 76,
-    maxBrightness: 100,
-    path: 'unknown',
-  },
-];
-
-export const bluetoothInfo = (): BluetoothInfo => [
-  {
-    address: '94:DB:56:E6:AA:78',
-    name: 'Headphone',
-    numConnectedDevices: 1,
-    powered: true,
-  },
-];
 
 export const vpdInfo = (): VpdInfo => ({
   skuNumber: 'sku',
   serialNumber: 'serial-number',
   modelName: 'model',
 });
-
-export const fanInfo = (): FanInfo => [
-  {
-    speedRpm: 2345,
-  },
-  {
-    speedRpm: 3245,
-  },
-  {
-    speedRpm: 1345,
-  },
-  {
-    speedRpm: 1350,
-  },
-];
 
 export const memoryInfo = (): MemoryInfo => ({
   totalMemoryKiB: 16270856,
@@ -86,11 +50,6 @@ export const blockDeviceInfo = (): BlockDeviceInfo => [
     discardTimeSecondsSinceLastBoot: '0',
   },
 ];
-
-export const timezoneInfo = (): TimezoneInfo => ({
-  posix: 'IST-5:30',
-  region: 'India',
-});
 
 export const statefulPartitionInfo = (): StatefulPartitionInfo => ({
   availableSpace: '1340000',

--- a/diagnostics-extension/src/services/telemetry.ts
+++ b/diagnostics-extension/src/services/telemetry.ts
@@ -7,16 +7,12 @@
  */
 
 import {
-  BacklightInfo,
   BatteryInfo,
   BlockDeviceInfo,
-  BluetoothInfo,
   CpuInfo,
-  FanInfo,
   MemoryInfo,
   OemData,
   StatefulPartitionInfo,
-  TimezoneInfo,
   VpdInfo,
 } from '@common/dpsl';
 import * as fakeData from './fake_telemetry.data';
@@ -28,22 +24,13 @@ import { ResponseErrorInfoMessage } from '@common/message';
  * service to fetch system telemetry data
  */
 export abstract class TelemetryService {
-  getBacklightInfo(): Promise<BacklightInfo> {
-    return Promise.reject(ResponseErrorInfoMessage.UnsupportedTelemetryFunction);
-  }
   getBatteryInfo(): Promise<BatteryInfo> {
-    return Promise.reject(ResponseErrorInfoMessage.UnsupportedTelemetryFunction);
-  }
-  getBluetoothInfo(): Promise<BluetoothInfo> {
     return Promise.reject(ResponseErrorInfoMessage.UnsupportedTelemetryFunction);
   }
   getCachedVpdInfo(): Promise<VpdInfo> {
     return Promise.reject(ResponseErrorInfoMessage.UnsupportedTelemetryFunction);
   }
   getCpuInfo(): Promise<CpuInfo> {
-    return Promise.reject(ResponseErrorInfoMessage.UnsupportedTelemetryFunction);
-  }
-  getFanInfo(): Promise<FanInfo> {
     return Promise.reject(ResponseErrorInfoMessage.UnsupportedTelemetryFunction);
   }
   getMemoryInfo(): Promise<MemoryInfo> {
@@ -56,9 +43,6 @@ export abstract class TelemetryService {
     return Promise.reject(ResponseErrorInfoMessage.UnsupportedTelemetryFunction);
   }
   getStatefulPartitionInfo(): Promise<StatefulPartitionInfo> {
-    return Promise.reject(ResponseErrorInfoMessage.UnsupportedTelemetryFunction);
-  }
-  getTimezoneInfo(): Promise<TimezoneInfo> {
     return Promise.reject(ResponseErrorInfoMessage.UnsupportedTelemetryFunction);
   }
 }
@@ -96,23 +80,14 @@ export class TelemetryServiceImpl extends TelemetryService {
  * @extends TelemetryService
  */
 export class FakeTelemetryService extends TelemetryService {
-  async getBacklightInfo(): Promise<BacklightInfo> {
-    return fakeData.backlightInfo();
-  }
   async getBatteryInfo(): Promise<BatteryInfo> {
     return fakeData.batteryInfo();
-  }
-  async getBluetoothInfo(): Promise<BluetoothInfo> {
-    return fakeData.bluetoothInfo();
   }
   async getCachedVpdInfo(): Promise<VpdInfo> {
     return fakeData.vpdInfo();
   }
   async getCpuInfo(): Promise<CpuInfo> {
     return fakeData.cpuInfo();
-  }
-  async getFanInfo(): Promise<FanInfo> {
-    return fakeData.fanInfo();
   }
   async getMemoryInfo(): Promise<MemoryInfo> {
     return fakeData.memoryInfo();
@@ -125,9 +100,6 @@ export class FakeTelemetryService extends TelemetryService {
   }
   async getStatefulPartitionInfo(): Promise<StatefulPartitionInfo> {
     return fakeData.statefulPartitionInfo();
-  }
-  async getTimezoneInfo(): Promise<TimezoneInfo> {
-    return fakeData.timezoneInfo();
   }
 }
 


### PR DESCRIPTION
Since there are some unsupported Telemetry service in the current app (e.g. getBacklightInfo, getBluetoothInfo), they should be removed.
- Remove the interfaces in dpsl.ts
- Remove the Telemetry service functions in both app and extension
- Remove the enum values in message.ts
- Update unit tests in extension
- Remove fake data in fake_telemetry.data.ts in extension

BUG: b/297831101