### PR TITLE
[UI] Add telemetry base card

### DIFF
--- a/diagnostics-app/src/app/core/config/data-refresh-intervals.ts
+++ b/diagnostics-app/src/app/core/config/data-refresh-intervals.ts
@@ -1,5 +1,11 @@
-export const refreshIntervals = new Map<string, number> ([
-    ['memory', 1000],
-    ['storage', 60000],
-    ['cpu', 1000],
-])
+import { TelemetryInfoType } from '@common/message';
+
+export const defaultTelemetryRefreshInterval = 10000;
+
+export const refreshIntervals = {
+    telemetry: new Map<string, number> ([
+        [TelemetryInfoType.BATTERY, 1000],
+        [TelemetryInfoType.CPU, 1000],
+        [TelemetryInfoType.STATEFUL_PARTITION, 60000]
+    ])
+}

--- a/diagnostics-app/src/app/shared/material.module.ts
+++ b/diagnostics-app/src/app/shared/material.module.ts
@@ -13,25 +13,28 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatToolbarModule } from '@angular/material/toolbar';
 
 @NgModule({
   imports: [
-    MatToolbarModule,
-    MatIconModule,
     MatButtonModule,
-    MatSidenavModule,
-    MatListModule,
     MatDividerModule,
+    MatIconModule,
+    MatListModule,
+    MatProgressSpinnerModule,
+    MatSidenavModule,
+    MatToolbarModule,
   ],
   exports: [
-    MatToolbarModule,
-    MatIconModule,
     MatButtonModule,
-    MatSidenavModule,
-    MatListModule,
     MatDividerModule,
+    MatIconModule,
+    MatListModule,
+    MatProgressSpinnerModule,
+    MatSidenavModule,
+    MatToolbarModule,
   ],
 })
 export class MaterialModule {}

--- a/diagnostics-app/src/app/telemetry/telemetry-card/telemetry-card-content/telemetry-card-content.component.css
+++ b/diagnostics-app/src/app/telemetry/telemetry-card/telemetry-card-content/telemetry-card-content.component.css
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2023 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+  /* This is used for indentation */
+  .telemetry-card-content {
+    margin-left: 20px;
+  }

--- a/diagnostics-app/src/app/telemetry/telemetry-card/telemetry-card-content/telemetry-card-content.component.html
+++ b/diagnostics-app/src/app/telemetry/telemetry-card/telemetry-card-content/telemetry-card-content.component.html
@@ -1,0 +1,16 @@
+<!--
+ Copyright 2023 The Chromium Authors. All rights reserved.
+ Use of this source code is governed by a BSD-style license that can be
+ found in the LICENSE file.
+-->
+
+<div class="telemetry-card-content" *ngFor="let item of $any(info) | keyvalue: originalOrder">
+  <b>{{ item.key }}</b>:
+  <ng-container *ngIf="isPrimitiveType(item.value); then renderPrimitive; else renderSubobject"></ng-container>
+  <ng-template #renderPrimitive>
+    {{ item.value }}
+  </ng-template>
+  <ng-template #renderSubobject>
+    <app-telemetry-card-content [info]="item.value"></app-telemetry-card-content>
+  </ng-template>
+</div>

--- a/diagnostics-app/src/app/telemetry/telemetry-card/telemetry-card-content/telemetry-card-content.component.spec.ts
+++ b/diagnostics-app/src/app/telemetry/telemetry-card/telemetry-card-content/telemetry-card-content.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TelemetryCardContentComponent } from './telemetry-card-content.component';
+
+describe('TelemetryCardContentComponent', () => {
+  let component: TelemetryCardContentComponent;
+  let fixture: ComponentFixture<TelemetryCardContentComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TelemetryCardContentComponent]
+    });
+    fixture = TestBed.createComponent(TelemetryCardContentComponent);
+    component = fixture.componentInstance;
+    component.info = {};
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/diagnostics-app/src/app/telemetry/telemetry-card/telemetry-card-content/telemetry-card-content.component.ts
+++ b/diagnostics-app/src/app/telemetry/telemetry-card/telemetry-card-content/telemetry-card-content.component.ts
@@ -1,0 +1,29 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/**
+ * @fileoverview Defines the CardContent Component in Telemetry.
+ * Imported by telemetry.module.ts
+ */
+
+import { Component, Input } from '@angular/core';
+import { KeyValue } from '@angular/common';
+
+@Component({
+  selector: 'app-telemetry-card-content',
+  templateUrl: './telemetry-card-content.component.html',
+  styleUrls: ['./telemetry-card-content.component.css']
+})
+export class TelemetryCardContentComponent {
+  @Input({ required: true }) info!: Object;
+
+  // this function is used for maintaining the attributes' original order
+  public originalOrder = (a: KeyValue<number, string>, b: KeyValue<number, string>): number => 0;
+
+  public isPrimitiveType(a: any) {
+    return typeof a !== 'object';
+  }
+
+  constructor() {}
+}

--- a/diagnostics-app/src/app/telemetry/telemetry-card/telemetry-card.component.css
+++ b/diagnostics-app/src/app/telemetry/telemetry-card/telemetry-card.component.css
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+  .telemetry-card {
+    background-color: var(--app-dashboard-card-background);
+    padding: 3rem;
+    border-radius: 3px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    font-size: 14px;
+    color: var(--app-dashboard-card-color);
+  }
+  
+  .telemetry-card header {
+    font-size: 18px;
+    font-weight: 500;
+    margin-bottom: 1rem;
+  }
+
+  .error-message {
+    color: var(--app-error-message-color);
+    border-radius: 5px;
+    padding: 1rem;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .loading-spinner {
+    margin: auto;
+  }
+  

--- a/diagnostics-app/src/app/telemetry/telemetry-card/telemetry-card.component.html
+++ b/diagnostics-app/src/app/telemetry/telemetry-card/telemetry-card.component.html
@@ -1,0 +1,28 @@
+<!-- 
+ Copyright 2023 The Chromium Authors. All rights reserved.
+ Use of this source code is governed by a BSD-style license that can be
+ found in the LICENSE file.
+-->
+
+<div class="telemetry-card">
+    <header>{{ type.toUpperCase() }}</header>
+    <ng-container *ngIf="info; then renderCardContent; else renderLoadingOrError"></ng-container>
+    <ng-template #renderCardContent>
+        <app-telemetry-card-content [info]="info!"></app-telemetry-card-content>
+    </ng-template>
+    <ng-template #renderLoadingOrError>
+        <ng-container *ngIf="error; then showError; else showLoading"></ng-container>
+        <ng-template #showError>
+            <div class="error-message">
+                <mat-icon mat-list-icon>warning</mat-icon>
+                {{ error }}
+            </div>
+        </ng-template>
+        <ng-template #showLoading>
+            <mat-spinner 
+                [diameter]="20"
+                class="loading-spinner">
+            </mat-spinner>
+        </ng-template>
+    </ng-template>
+</div>

--- a/diagnostics-app/src/app/telemetry/telemetry-card/telemetry-card.component.spec.ts
+++ b/diagnostics-app/src/app/telemetry/telemetry-card/telemetry-card.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TelemetryCardComponent } from './telemetry-card.component';
+import { TelemetryInfoType } from '@common/message';
+
+describe('TelemetryCardComponent', () => {
+  let component: TelemetryCardComponent;
+  let fixture: ComponentFixture<TelemetryCardComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TelemetryCardComponent]
+    });
+    fixture = TestBed.createComponent(TelemetryCardComponent);
+    component = fixture.componentInstance;
+    component.type = TelemetryInfoType.BATTERY;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/diagnostics-app/src/app/telemetry/telemetry-card/telemetry-card.component.ts
+++ b/diagnostics-app/src/app/telemetry/telemetry-card/telemetry-card.component.ts
@@ -1,0 +1,59 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/**
+ * @fileoverview Defines the Card Component in Telemetry.
+ * Imported by telemetry.module.ts
+ */
+
+import { Component, Input, OnInit, OnDestroy } from '@angular/core';
+
+import { DpslTypes } from '@common/dpsl';
+import { TelemetryService } from 'src/app/core/services/telemetry.service';
+import { TelemetryInfoType, ResponseErrorInfoMessage } from '@common/message';
+import { defaultTelemetryRefreshInterval, refreshIntervals } from '../../core/config/data-refresh-intervals';
+
+@Component({
+  selector: 'app-telemetry-card',
+  templateUrl: './telemetry-card.component.html',
+  styleUrls: ['./telemetry-card.component.css'],
+})
+export class TelemetryCardComponent implements OnInit, OnDestroy {
+  @Input({ required: true }) type!: TelemetryInfoType;
+
+  private _error?: ResponseErrorInfoMessage; // the error message received, null if no error occurs
+  private _intervalId!: number; // the interval id of this card component
+  private _info?: DpslTypes; // the telemetry info received by calling telemetry service
+
+  get error() { return this._error; }
+  get info() { return this._info; }
+
+  private _updateData(type: TelemetryInfoType) {
+    let promise = <Promise<DpslTypes>>(this.telemetryService.fetchTelemetryData(type));
+    promise.then((value: DpslTypes) => {
+      this._error = undefined;
+      this._info = value;
+    }).catch(e => {
+      this._error = e.message;
+      this._info = undefined;
+    });
+  }
+
+  constructor(private telemetryService: TelemetryService) {}
+
+  ngOnInit(): void {
+    let type = this.type;
+    let interval = (refreshIntervals.telemetry.has(type)) ?
+      refreshIntervals.telemetry.get(type) : defaultTelemetryRefreshInterval;
+
+    this._updateData(type);
+    this._intervalId = window.setInterval(() => {
+      this._updateData(type);
+    }, interval);
+  }
+
+  ngOnDestroy(): void {
+    window.clearInterval(this._intervalId);
+  }
+}

--- a/diagnostics-app/src/app/telemetry/telemetry-dashboard/telemetry-dashboard.component.css
+++ b/diagnostics-app/src/app/telemetry/telemetry-dashboard/telemetry-dashboard.component.css
@@ -4,45 +4,12 @@
  * found in the LICENSE file.
  */
 
-.row {
-  margin-bottom: 1rem;
-}
-
-.header .laptop-name {
-  font-size: 32px;
-  font-weight: 500;
-  margin-bottom: 0.5rem;
-}
-
-.header .os-version {
-  font-size: 24px;
-}
-
-.app-spec-list {
-  list-style: none;
-  padding: 0;
-}
-
-.app-spec-list p {
-  font-size: 20px;
-  margin-bottom: 1rem;
-}
-
-.card-container-placeholder {
-  background-color: var(--app-dashboard-card-background);
-  padding: 3rem;
-  border-radius: 3px;
+ .telemetry-dashboard {
   display: flex;
-  justify-content: center;
-  font-size: 24px;
-  color: var(--app-dashboard-card-color);
-}
+  flex-direction: row;
+  flex-wrap: wrap;
+ }
 
-.card-container {
-  background-color: var(--app-dashboard-card-background);
-  padding: .5rem 1rem;
-  border-radius: 3px;
-  font-size: 18px;
-  color: var(--app-dashboard-card-color);
-  border: 1px solid var(--app-dashboard-card-border-color);
-}
+ .telemetry-card-container {
+  margin: 8px;
+ }

--- a/diagnostics-app/src/app/telemetry/telemetry-dashboard/telemetry-dashboard.component.html
+++ b/diagnostics-app/src/app/telemetry/telemetry-dashboard/telemetry-dashboard.component.html
@@ -4,3 +4,8 @@
  found in the LICENSE file.
 -->
 
+<div class="telemetry-dashboard">
+  <div class="telemetry-card-container" *ngFor="let type of visibleTypes">
+    <app-telemetry-card [type]="type"></app-telemetry-card>
+  </div>
+</div>

--- a/diagnostics-app/src/app/telemetry/telemetry-dashboard/telemetry-dashboard.component.ts
+++ b/diagnostics-app/src/app/telemetry/telemetry-dashboard/telemetry-dashboard.component.ts
@@ -3,20 +3,29 @@
 // found in the LICENSE file.
 
 /**
- * @fileoverview Defines the Dashboard Component.
- * This is the root layout component which holds the dashboard.
- * Imported by dashboard.module.ts
+ * @fileoverview Defines the Dashboard Component in Telemetry.
+ * This is the root layout component which holds the telemetry dashboard.
+ * Imported by telemetry.module.ts
  */
 
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
+import { TelemetryInfoType } from '@common/message';
 
 @Component({
   selector: 'app-telemetry-dashboard',
   templateUrl: './telemetry-dashboard.component.html',
   styleUrls: ['./telemetry-dashboard.component.css'],
 })
-export class TelemetryDashboardComponent implements OnInit {
-  constructor() {}
+export class TelemetryDashboardComponent {
+  // Array of telemetry info types that will be displayed
+  private _visibleTypes: TelemetryInfoType[] = [
+    TelemetryInfoType.BATTERY,
+    TelemetryInfoType.BLOCK_DEVICE,
+    TelemetryInfoType.CPU,
+    TelemetryInfoType.MEMORY,
+    TelemetryInfoType.STATEFUL_PARTITION,
+    TelemetryInfoType.VPD,
+  ];
 
-  ngOnInit(): void {}
+  get visibleTypes() { return this._visibleTypes; }
 }

--- a/diagnostics-app/src/app/telemetry/telemetry.module.ts
+++ b/diagnostics-app/src/app/telemetry/telemetry.module.ts
@@ -10,11 +10,13 @@
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SharedModule } from '../shared/shared.module';
+import { TelemetryCardComponent } from './telemetry-card/telemetry-card.component';
 import { TelemetryCardContentComponent } from './telemetry-card/telemetry-card-content/telemetry-card-content.component';
 import { TelemetryDashboardComponent } from './telemetry-dashboard/telemetry-dashboard.component';
 
 @NgModule({
   declarations: [
+    TelemetryCardComponent,
     TelemetryCardContentComponent,
     TelemetryDashboardComponent
   ],

--- a/diagnostics-app/src/app/telemetry/telemetry.module.ts
+++ b/diagnostics-app/src/app/telemetry/telemetry.module.ts
@@ -9,11 +9,15 @@
 
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { TelemetryDashboardComponent } from './telemetry-dashboard/telemetry-dashboard.component';
 import { SharedModule } from '../shared/shared.module';
+import { TelemetryCardContentComponent } from './telemetry-card/telemetry-card-content/telemetry-card-content.component';
+import { TelemetryDashboardComponent } from './telemetry-dashboard/telemetry-dashboard.component';
 
 @NgModule({
-  declarations: [TelemetryDashboardComponent],
+  declarations: [
+    TelemetryCardContentComponent,
+    TelemetryDashboardComponent
+  ],
   imports: [CommonModule, SharedModule],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })

--- a/diagnostics-app/src/styles/theme.css
+++ b/diagnostics-app/src/styles/theme.css
@@ -12,6 +12,7 @@
   --color-white: #fff;
   --color-fc: #f7f7f7;
   --color-blue: #4c8bf5;
+  --color-yellow: #e0b300;
 
   --app-background: var(--color-white);
 
@@ -31,6 +32,8 @@
   --app-dashboard-card-background: var(--color-white);
   --app-dashboard-card-color: var(--color-black);
   --app-dashboard-card-border-color: #ccc;
+
+  --app-error-message-color: var(--color-yellow)
 }
 
 .dark {
@@ -43,6 +46,7 @@
   --color-darker-white: #989898;
   --color-dark-white: #e3e3e3;
   --color-blue: #4c8bf5;
+  --color-yellow: #e0b300;
 
   --color-white: #fff;
 
@@ -66,4 +70,6 @@
   --app-dashboard-card-background: var(--color-dark-grey);
   --app-dashboard-card-color: var(--color-white);
   --app-dashboard-card-border-color: #333;
+
+  --app-error-message-color: var(--color-yellow)
 }


### PR DESCRIPTION
Telemetry base card is implemented in this PR.
- Change data refresh interval format
- Create TelemetryCardContent Component
- Create TelemetryCard Component
- Implement TelemetryDashboard Component

The original telemetry page looks like: https://screenshot.googleplex.com/Eu8rVJEqLqaHXzu.png, and with base cards, it looks like: https://screenshot.googleplex.com/Bwrrpth62HnrPY4.png.

BUG: b/295126796