### PR TITLE
[Extension] Fix the response type for getAvailableRoutines

### DIFF
--- a/diagnostics-extension/src/controllers/diagnostics.ts
+++ b/diagnostics-extension/src/controllers/diagnostics.ts
@@ -8,6 +8,7 @@
 
 import {
   DiagnosticsParams,
+  GetAvailableRoutinesResponse,
   RoutineStatus,
   RoutineType,
   RunRoutineResponse,
@@ -35,8 +36,7 @@ const diagnosticsService = DiagnosticsServiceProvider.getDiagnosticsService();
 const getAvailableRoutines = async (
   res: (data: Response) => void
 ) => {
-  const routines: RoutineType[] = await diagnosticsService.getAvailableRoutines();
-  const payload: DiagnosticsResponse = { routines };
+  const payload: GetAvailableRoutinesResponse = await diagnosticsService.getAvailableRoutines();
   return res(generateDiagnosticsSuccessResponse(payload));
 }
 

--- a/diagnostics-extension/src/services/diagnostics.ts
+++ b/diagnostics-extension/src/services/diagnostics.ts
@@ -11,13 +11,11 @@ import {
   RoutineCommandType,
   RoutineType,
   RunRoutineResponse,
+  GetAvailableRoutinesResponse,
   GetRoutineUpdateRequest,
   GetRoutineUpdateResponse,
 } from '@common/dpsl';
-import {
-  DiagnosticsAction,
-  ResponseErrorInfoMessage,
-} from '@common/message';
+import { ResponseErrorInfoMessage } from '@common/message';
 import * as fake_diagnostics from './fake_diagnostics.data';
 import { Routine } from './fake_diagnostics.data';
 import { environment } from '../environments/environment';
@@ -27,7 +25,7 @@ import { environment } from '../environments/environment';
  * service to run diagnostics routines
  */
 export abstract class DiagnosticsService {
-  abstract getAvailableRoutines(): Promise<RoutineType[]>;
+  abstract getAvailableRoutines(): Promise<GetAvailableRoutinesResponse>;
   abstract startRoutine(
     name: RoutineType,
     params?: DiagnosticsParams
@@ -43,7 +41,7 @@ export abstract class DiagnosticsService {
  */
 export class DiagnosticsServiceImpl extends DiagnosticsService {
 
-  getAvailableRoutines = async (): Promise<RoutineType[]> => {
+  getAvailableRoutines = async (): Promise<GetAvailableRoutinesResponse> => {
     return (chrome as any).os.diagnostics.getAvailableRoutines();
   }
 
@@ -160,7 +158,7 @@ export class FakeDiagnosticsService implements DiagnosticsService {
     return this._activeRoutines[id];
   };
 
-  getAvailableRoutines = async (): Promise<RoutineType[]> => {
+  getAvailableRoutines = async (): Promise<GetAvailableRoutinesResponse> => {
     return fake_diagnostics.fakeAvailableRoutines();
   }
 

--- a/diagnostics-extension/src/services/fake_diagnostics.data.ts
+++ b/diagnostics-extension/src/services/fake_diagnostics.data.ts
@@ -11,6 +11,7 @@ import {
   RoutineStatus,
   RoutineType,
   RunRoutineResponse,
+  GetAvailableRoutinesResponse,
   GetRoutineUpdateResponse,
   UserMessageType
 } from '@common/dpsl';
@@ -19,39 +20,41 @@ const generateRandomId = () => {
   return Math.floor(Math.random() * 10000);
 };
 
-export const fakeAvailableRoutines = async (): Promise<RoutineType[]> => {
-  return [
-    RoutineType.ac_power,
-    RoutineType.audio_driver,
-    RoutineType.battery_capacity,
-    RoutineType.battery_charge,
-    RoutineType.battery_discharge,
-    RoutineType.battery_health,
-    RoutineType.bluetooth_discovery,
-    RoutineType.bluetooth_pairing,
-    RoutineType.bluetooth_power,
-    RoutineType.bluetooth_scanning,
-    RoutineType.cpu_cache,
-    RoutineType.cpu_floating_point_accuracy,
-    RoutineType.cpu_prime_search,
-    RoutineType.cpu_stress,
-    RoutineType.disk_read,
-    RoutineType.dns_resolution,
-    RoutineType.dns_resolver_present,
-    RoutineType.emmc_lifetime,
-    RoutineType.fingerprint_alive,
-    RoutineType.gateway_can_be_pinged,
-    RoutineType.lan_connectivity,
-    RoutineType.memory,
-    RoutineType.nvme_self_test,
-    RoutineType.nvme_wear_level,
-    RoutineType.power_button,
-    RoutineType.sensitive_sensor,
-    RoutineType.signal_strength,
-    RoutineType.smartctl_check,
-    RoutineType.smartctl_check_with_percentage_used,
-    RoutineType.ufs_lifetime,
-  ]
+export const fakeAvailableRoutines = async (): Promise<GetAvailableRoutinesResponse> => {
+  return {
+    routines: [
+      RoutineType.ac_power,
+      RoutineType.audio_driver,
+      RoutineType.battery_capacity,
+      RoutineType.battery_charge,
+      RoutineType.battery_discharge,
+      RoutineType.battery_health,
+      RoutineType.bluetooth_discovery,
+      RoutineType.bluetooth_pairing,
+      RoutineType.bluetooth_power,
+      RoutineType.bluetooth_scanning,
+      RoutineType.cpu_cache,
+      RoutineType.cpu_floating_point_accuracy,
+      RoutineType.cpu_prime_search,
+      RoutineType.cpu_stress,
+      RoutineType.disk_read,
+      RoutineType.dns_resolution,
+      RoutineType.dns_resolver_present,
+      RoutineType.emmc_lifetime,
+      RoutineType.fingerprint_alive,
+      RoutineType.gateway_can_be_pinged,
+      RoutineType.lan_connectivity,
+      RoutineType.memory,
+      RoutineType.nvme_self_test,
+      RoutineType.nvme_wear_level,
+      RoutineType.power_button,
+      RoutineType.sensitive_sensor,
+      RoutineType.signal_strength,
+      RoutineType.smartctl_check,
+      RoutineType.smartctl_check_with_percentage_used,
+      RoutineType.ufs_lifetime,
+    ]
+  }
 }
 
 export const runAcPowerRoutine = async (params: DiagnosticsParams): Promise<RunRoutineResponse> => {


### PR DESCRIPTION
The response type of diagnostics routine getAvailableRoutines() should be 'GetAvailableRoutinesResponse', which contains one field 'routines' with an array of RoutineType as value.

BUG: b/295126759