### PR TITLE
[Extension] Add error handling for diagnostics

### DIFF
--- a/diagnostics-extension/src/controllers/diagnostics.ts
+++ b/diagnostics-extension/src/controllers/diagnostics.ts
@@ -36,8 +36,12 @@ const diagnosticsService = DiagnosticsServiceProvider.getDiagnosticsService();
 const getAvailableRoutines = async (
   res: (data: Response) => void
 ) => {
-  const payload: GetAvailableRoutinesResponse = await diagnosticsService.getAvailableRoutines();
-  return res(generateDiagnosticsSuccessResponse(payload));
+  try {
+    const payload: GetAvailableRoutinesResponse = await diagnosticsService.getAvailableRoutines();
+    return res(generateDiagnosticsSuccessResponse(payload));
+  } catch (err) {
+    return res(generateErrorResponse(String(err)));
+  }
 }
 
 const handleStartRoutine = async (


### PR DESCRIPTION
If an error occurs when calling the getAvailableRoutines API, it catches the error and returns its error message.

BUG: b/295126759