### PR TITLE
Extend Telemetry Service functions

### DIFF
--- a/common/dpsl.ts
+++ b/common/dpsl.ts
@@ -7,42 +7,81 @@
  */
 
 /**
+ * Information about an Audio input node
+ */
+export interface AudioInputNodeInfo {
+  id?: number;
+  name?: string;
+  deviceName?: string;
+  active?: boolean;
+  nodeGain?: number;
+}
+
+/**
+ * Information about an Audio output node
+ */
+export interface AudioOutputNodeInfo {
+  id?: number;
+  name?: string;
+  deviceName?: string;
+  active?: boolean;
+  nodeVolume?: number;
+}
+
+/**
+ * Response message containing Audio Info
+ */
+export interface AudioInfo {
+  outputMute?: boolean;
+  inputMute?: boolean;
+  underruns?: number;
+  severeUnderruns?: number;
+  outputNodes: AudioOutputNodeInfo[];
+  inputNodes: AudioInputNodeInfo[];
+}
+
+/**
  * Response message containing Battery Info
  */
 export interface BatteryInfo {
-  cycleCount: string;
-  voltageNow: number;
-  vendor: string;
-  serialNumber: string;
-  chargeFullDesign: number;
-  chargeFull: number;
-  voltageMinDesign: number;
-  modelName: string;
-  chargeNow: number;
-  currentNow: number;
-  technology: string;
-  status: string;
-  manufactureDate: string;
-  temperature: string;
+  cycleCount?: number;
+  voltageNow?: number;
+  vendor?: string;
+  serialNumber?: string;
+  chargeFullDesign?: number;
+  chargeFull?: number;
+  voltageMinDesign?: number;
+  modelName?: string;
+  chargeNow?: number;
+  currentNow?: number;
+  technology?: string;
+  status?: string;
+  manufactureDate?: string;
+  temperature?: number;
 }
 
 /**
- * Response message containing VPD Info
+ * Information about a Non Removable Block Device
  */
-export interface VpdInfo {
-  skuNumber: string;
-  serialNumber: string;
-  modelName: string;
+export interface NonRemovableBlockDeviceInfo {
+  name?: string;
+  type?: string;
+  size?: number;
 }
 
 /**
- * Types of CPU architecture
+ * Response message containing Non Removable Block Device Info
+ */
+export type NonRemovableBlockDeviceInfoResponse = NonRemovableBlockDeviceInfo[];
+
+/**
+ * Types of CPU architectures
  */
 export const enum CpuArchitectureEnum {
-  unknown,
-  x86_64,
-  aarch64,
-  armv7l
+  unknown = 'unknown',
+  x86_64 = 'x86_64',
+  aarch64 = 'aarch64',
+  armv7l = 'armv7l',
 };
 
 /**
@@ -54,22 +93,22 @@ export interface CpuCStateInfo {
 }
 
 /**
- * Information related to a particular logical CPU.
+ * Information about a particular logical CPU
  */
 export interface LogicalCpuInfo {
-  maxClockSpeedKhz: number;
-  scalingMaxFrequencyKhz: number;
-  scalingCurrentFrequencyKhz: number;
-  idleTimeMs: number;
+  maxClockSpeedKhz?: number;
+  scalingMaxFrequencyKhz?: number;
+  scalingCurrentFrequencyKhz?: number;
+  idleTimeMs?: number;
   cStates: CpuCStateInfo[];
-  coreId: number;
+  coreId?: number;
 }
 
 /**
- * Information related to a particular physical CPU.
+ * Information about a particular physical CPU
  */
 export interface PhysicalCpuInfo {
-  modelName: string;
+  modelName?: string;
   logicalCpus: LogicalCpuInfo[];
 }
 
@@ -77,19 +116,126 @@ export interface PhysicalCpuInfo {
  * Response message containing CPU Info
  */
 export interface CpuInfo {
-  numTotalThreads: number;
+  numTotalThreads?: number;
   architecture: CpuArchitectureEnum;
   physicalCpus: PhysicalCpuInfo[];
+}
+
+/**
+ * Types of display inputs
+ */
+export const enum DisplayInputType {
+  unknown = 'unknown',
+  digital = 'digital',
+  analog = 'analog',
+}
+
+/**
+ * Information about an embedded display
+ */
+export interface EmbeddedDisplayInfo {
+  privacyScreenSupported?: boolean;
+  privacyScreenEnabled?: boolean;
+  displayWidth?: number;
+  displayHeight?: number;
+  resolutionHorizontal?: number;
+  resolutionVertical?: number;
+  refreshRate?: number;
+  manufacturer?: string;
+  modelId?: number;
+  serialNumber?: number;
+  manufactureWeek?: number;
+  manufactureYear?: number;
+  edidVersion?: string;
+  inputType: DisplayInputType;
+  displayName?: string;
+}
+
+/**
+ * Information about a external display
+ */
+export interface ExternalDisplayInfo {
+  displayWidth?: number;
+  displayHeight?: number;
+  resolutionHorizontal?: number;
+  resolutionVertical?: number;
+  refreshRate?: number;
+  manufacturer?: string;
+  modelId?: number;
+  serialNumber?: number;
+  manufactureWeek?: number;
+  manufactureYear?: number;
+  edidVersion?: string;
+  inputType: DisplayInputType;
+  displayName?: string;
+}
+
+/**
+ * Response message containing Display Info
+ */
+export interface DisplayInfo {
+  embeddedDisplay: EmbeddedDisplayInfo;
+  externalDisplays: ExternalDisplayInfo[];
+}
+
+/**
+ * Response message containing Marketing Info
+ */
+export interface MarketingInfo {
+  marketingName?: string;
 }
 
 /**
  * Response message containing Memory Info
  */
 export interface MemoryInfo {
-  totalMemoryKiB: number;
-  freeMemoryKiB: number;
-  availableMemoryKiB: number;
-  pageFaultsSinceLastBoot: string;
+  totalMemoryKiB?: number;
+  freeMemoryKiB?: number;
+  availableMemoryKiB?: number;
+  pageFaultsSinceLastBoot?: string;
+}
+
+/**
+ * Types of networks
+ */
+export const enum NetworkType {
+  cellular = 'cellular',
+  ethernet = 'ethernet',
+  tether = 'tether',
+  vpn = 'vpn',
+  wifi = 'wifi',
+}
+
+/**
+ * Types of network states
+ */
+export const enum NetworkState {
+  uninitialized = 'uninitialized',
+  disabled = 'disabled',
+  prohibited = 'prohibited',
+  not_connected = 'not_connected',
+  connecting = 'connecting',
+  portal = 'portal',
+  connected = 'connected',
+  online = 'online',
+}
+
+/**
+ * Information about a network
+ */
+export interface NetworkInfo {
+  type?: NetworkType;
+  state?: NetworkState;
+  macAddress?: string;
+  ipv6Addresses: string[];
+  signalStrength?: number;
+}
+
+/**
+ * Response message containing Interrnet connectivity Info
+ */
+export interface InternetConnectivityInfo {
+  networks: NetworkInfo[];
 }
 
 /**
@@ -100,34 +246,163 @@ export interface OemData {
 }
 
 /**
- * Response message containing BlockDevice Info
+ * Response message containing OS version Info
  */
-export interface BlockDeviceInfoObject {
-  path: string;
-  size: string;
-  type: string;
-  manufacturerId: number;
-  name: string;
-  serial: string;
-  bytesReadSinceLastBoot: string;
-  bytesWrittenSinceLastBoot: string;
-  readTimeSecondsSinceLastBoot: string;
-  writeTimeSecondsSinceLastBoot: string;
-  ioTimeSecondsSinceLastBoot: string;
-  discardTimeSecondsSinceLastBoot: string;
+export interface OsVersionInfo {
+  releaseMilestone?: string;
+  buildNumber?: string;
+  patchNumber?: string;
+  releaseChannel?: string;
 }
 
 /**
- * Response message containing BlockDevice Info
+ * Information about an usb bus interface
  */
-export type BlockDeviceInfo = BlockDeviceInfoObject[];
+export interface UsbBusInterfaceInfo {
+  interfaceNumber?: number;
+  classId?: number;
+  subclassId?: number;
+  protocolId?: number;
+  driver?: string;
+}
+
+/**
+ * Types of the formats of firmware version in fwpud
+ */
+export const enum FwupdVersionFormat {
+  plain = 'plain',
+  number = 'number',
+  pair = 'pair',
+  triplet = 'triplet',
+  quad = 'quad',
+  bcd = 'bcd',
+  intelMe = 'intelMe',
+  intelMe2 = 'intelMe2',
+  surfaceLegacy = 'surfaceLegacy',
+  surface = 'surface',
+  dellBios = 'dellBios',
+  hex = 'hex',
+}
+
+/**
+ * Information about a firmware version obtained from fwupd
+ */
+export interface FwupdFirmwareVersionInfo {
+  version?: string;
+  version_format?: FwupdVersionFormat;
+}
+
+/**
+ * Types of USB versions
+ */
+export const enum UsbVersion {
+  unknown = 'unknown',
+  usb1 = 'usb1',
+  usb2 = 'usb2',
+  usb3 = 'usb3',
+}
+
+/**
+ * Types of USB spec speeds in Mbps
+ */
+export const enum UsbSpecSpeed {
+  unknown = 'unknown',
+  n1_5Mbps = 'n1_5Mbps',
+  n12Mbps = 'n12Mbps',
+  n480Mbps = 'n480Mbps',
+  n5Gbps = 'n5Gbps',
+  n10Gbps = 'n10Gbps',
+  n20Gbps = 'n20Gbps',
+}
+
+/**
+ * Information about an USB
+ */
+export interface UsbBusInfo {
+  classId?: number;
+  subclassId?: number;
+  protocolId?: number;
+  vendorId?: number;
+  productId?: number;
+  interfaces: UsbBusInterfaceInfo[];
+  fwupdFirmwareVersionInfo?: FwupdFirmwareVersionInfo;
+  version?: UsbVersion;
+  spec_speed?: UsbSpecSpeed;
+}
+
+/**
+ * Response message containing USB bus devices Info
+ */
+export interface UsbBusDevices {
+  devices: UsbBusInfo[];
+}
+
+/**
+ * Response message containing VPD Info
+ */
+export interface VpdInfo {
+  activateDate?: string;
+  modelName?: string;
+  serialNumber?: string;
+  skuNumber?: string;
+}
 
 /**
  * Response message containing StatefulPartition Info
  */
 export interface StatefulPartitionInfo {
-  availableSpace: string;
-  totalSpace: string;
+  availableSpace?: number;
+  totalSpace?: number;
+}
+
+/**
+ * Types of a TPM GSC versions
+ */
+export const enum TpmGSCVersion {
+  not_gsc = 'not_gsc',
+  cr50 = 'cr50',
+  ti50 = 'ti50',
+}
+
+/**
+ * Information about a TPM version
+ */
+export interface TpmVersion {
+  gscVersion?: TpmGSCVersion;
+  family?: number;
+  specLevel?: number;
+  manufacturer?: number;
+  tpmModel?: number;
+  firmwareVersion?: number;
+  vendorSpecific?: string;
+}
+
+/**
+ * Information about a TPM status
+ */
+export interface TpmStatus {
+  enabled?: boolean;
+  owned?: boolean;
+  ownerPasswordIsPresent?: boolean;
+}
+
+/**
+ * Information about a TPM dictionary attack
+ */
+export interface TpmDictionaryAttack {
+  counter?: number;
+  threshold?: number;
+  lockoutInEffect?: boolean;
+  lockoutSecondsRemaining?: number;
+}
+
+/**
+ * Response message containing TPM Info
+ */
+export interface TpmInfo {
+  version: TpmVersion;
+  status: TpmStatus;
+  dictionaryAttack: TpmDictionaryAttack;
 }
 
 // chrome.os.diagnostics.* type definitions
@@ -356,12 +631,20 @@ export interface RunSmartctlCheckRequest {
 }
 
 export type TelemetryInfoUnion =
+  | AudioInfo
   | BatteryInfo
-  | VpdInfo
+  | NonRemovableBlockDeviceInfoResponse
   | CpuInfo
+  | DisplayInfo
+  | MarketingInfo
   | MemoryInfo
-  | BlockDeviceInfo
+  | InternetConnectivityInfo
+  | OemData
+  | OsVersionInfo
+  | UsbBusDevices
+  | VpdInfo
   | StatefulPartitionInfo
+  | TpmInfo
 
 export type DiagnosticsParams =
   | RunAcPowerRoutineRequest

--- a/common/message.ts
+++ b/common/message.ts
@@ -22,12 +22,20 @@ export const enum RequestType {
 }
 
 export const enum TelemetryInfoType {
+  AUDIO = 'audio',
   BATTERY = 'battery',
-  BLOCK_DEVICE = 'block-device',
+  BLOCK_DEVICE = 'block_device',
   CPU = 'cpu',
+  DISPLAY = 'display',
+  MARKETING = 'marketing',
   MEMORY = 'memory',
-  STATEFUL_PARTITION = 'stateful-partition',
+  NETWORK = 'network',
+  OEM = 'oem',
+  OS_VERSION = 'os_version',
+  USB = 'usb',
   VPD = 'vpd',
+  STATEFUL_PARTITION = 'stateful_partition',
+  TPM = 'tpm',
 }
 
 export const enum ResponseErrorInfoMessage {

--- a/diagnostics-extension/package-lock.json
+++ b/diagnostics-extension/package-lock.json
@@ -23,8 +23,8 @@
         "webpack-cli": "^4.10.0"
       },
       "engines": {
-        "node": "~18.13.0",
-        "npm": "~9.2.0"
+        "node": ">=18.14.0",
+        "npm": ">=9.2.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/diagnostics-extension/src/__tests__/controllers/telemetry.spec.ts
+++ b/diagnostics-extension/src/__tests__/controllers/telemetry.spec.ts
@@ -36,7 +36,7 @@ describe('should return correct error messages', () => {
     const req: Request = {
       type: RequestType.TELEMETRY,
       //@ts-ignore
-      telemetry: { info: 'CACHED_VPD' },
+      telemetry: { info: 'invalid_type' },
     };
     const res: (response: Response) => void = jest.fn();
 
@@ -80,34 +80,74 @@ describe('should return correct telemetry data', () => {
     expectedResult: TelemetryInfoUnion;
   }[] = [
     {
+      name: `audio`,
+      infoType: TelemetryInfoType.AUDIO,
+      expectedResult: fakeData.audioInfo,
+    },
+    {
       name: `battery`,
       infoType: TelemetryInfoType.BATTERY,
-      expectedResult: fakeData.batteryInfo(),
-    },
-    {
-      name: `vpd`,
-      infoType: TelemetryInfoType.VPD,
-      expectedResult: fakeData.vpdInfo(),
-    },
-    {
-      name: `cpu`,
-      infoType: TelemetryInfoType.CPU,
-      expectedResult: fakeData.cpuInfo(),
-    },
-    {
-      name: `memory`,
-      infoType: TelemetryInfoType.MEMORY,
-      expectedResult: fakeData.memoryInfo(),
+      expectedResult: fakeData.batteryInfo,
     },
     {
       name: `block device`,
       infoType: TelemetryInfoType.BLOCK_DEVICE,
-      expectedResult: fakeData.blockDeviceInfo(),
+      expectedResult: fakeData.blockDeviceInfo,
+    },
+    {
+      name: `cpu`,
+      infoType: TelemetryInfoType.CPU,
+      expectedResult: fakeData.cpuInfo,
+    },
+    {
+      name: `display`,
+      infoType: TelemetryInfoType.DISPLAY,
+      expectedResult: fakeData.displayInfo,
+    },
+    {
+      name: `marketing`,
+      infoType: TelemetryInfoType.MARKETING,
+      expectedResult: fakeData.marketingInfo,
+    },
+    {
+      name: `memory`,
+      infoType: TelemetryInfoType.MEMORY,
+      expectedResult: fakeData.memoryInfo,
+    },
+    {
+      name: `network`,
+      infoType: TelemetryInfoType.NETWORK,
+      expectedResult: fakeData.networkInfo,
+    },
+    {
+      name: `oem`,
+      infoType: TelemetryInfoType.OEM,
+      expectedResult: fakeData.oemInfo,
+    },
+    {
+      name: `os version`,
+      infoType: TelemetryInfoType.OS_VERSION,
+      expectedResult: fakeData.osVersionInfo,
+    },
+    {
+      name: `usb`,
+      infoType: TelemetryInfoType.USB,
+      expectedResult: fakeData.usbInfo,
+    },
+    {
+      name: `vpd`,
+      infoType: TelemetryInfoType.VPD,
+      expectedResult: fakeData.vpdInfo,
     },
     {
       name: `stateful partition`,
       infoType: TelemetryInfoType.STATEFUL_PARTITION,
-      expectedResult: fakeData.statefulPartitionInfo(),
+      expectedResult: fakeData.statefulPartitionInfo,
+    },
+    {
+      name: `tpm`,
+      infoType: TelemetryInfoType.TPM,
+      expectedResult: fakeData.tpmInfo,
     },
   ];
 

--- a/diagnostics-extension/src/__tests__/services/telemetry.spec.ts
+++ b/diagnostics-extension/src/__tests__/services/telemetry.spec.ts
@@ -33,34 +33,74 @@ describe('should return instance of FakeTelemetryService', () => {
     expectedResult: TelemetryInfoUnion;
   }[] = [
     {
+      name: `audio`,
+      methodUnderTest: telemetryService.getAudioInfo,
+      expectedResult: fakeData.audioInfo,
+    },
+    {
       name: `battery`,
       methodUnderTest: telemetryService.getBatteryInfo,
-      expectedResult: fakeData.batteryInfo(),
-    },
-    {
-      name: `vpd`,
-      methodUnderTest: telemetryService.getCachedVpdInfo,
-      expectedResult: fakeData.vpdInfo(),
-    },
-    {
-      name: `cpu`,
-      methodUnderTest: telemetryService.getCpuInfo,
-      expectedResult: fakeData.cpuInfo(),
-    },
-    {
-      name: `memory`,
-      methodUnderTest: telemetryService.getMemoryInfo,
-      expectedResult: fakeData.memoryInfo(),
+      expectedResult: fakeData.batteryInfo,
     },
     {
       name: `block device`,
       methodUnderTest: telemetryService.getNonRemovableBlockDevicesInfo,
-      expectedResult: fakeData.blockDeviceInfo(),
+      expectedResult: fakeData.blockDeviceInfo,
+    },
+    {
+      name: `cpu`,
+      methodUnderTest: telemetryService.getCpuInfo,
+      expectedResult: fakeData.cpuInfo,
+    },
+    {
+      name: `display`,
+      methodUnderTest: telemetryService.getDisplayInfo,
+      expectedResult: fakeData.displayInfo,
+    },
+    {
+      name: `marketing`,
+      methodUnderTest: telemetryService.getMarketingInfo,
+      expectedResult: fakeData.marketingInfo,
+    },
+    {
+      name: `memory`,
+      methodUnderTest: telemetryService.getMemoryInfo,
+      expectedResult: fakeData.memoryInfo,
+    },
+    {
+      name: `network`,
+      methodUnderTest: telemetryService.getInternetConnectivityInfo,
+      expectedResult: fakeData.networkInfo,
+    },
+    {
+      name: `oem`,
+      methodUnderTest: telemetryService.getOemData,
+      expectedResult: fakeData.oemInfo,
+    },
+    {
+      name: `os version`,
+      methodUnderTest: telemetryService.getOsVersionInfo,
+      expectedResult: fakeData.osVersionInfo,
+    },
+    {
+      name: `usb`,
+      methodUnderTest: telemetryService.getUsbBusInfo,
+      expectedResult: fakeData.usbInfo,
+    },
+    {
+      name: `vpd`,
+      methodUnderTest: telemetryService.getVpdInfo,
+      expectedResult: fakeData.vpdInfo,
     },
     {
       name: `stateful partition`,
       methodUnderTest: telemetryService.getStatefulPartitionInfo,
-      expectedResult: fakeData.statefulPartitionInfo(),
+      expectedResult: fakeData.statefulPartitionInfo,
+    },
+    {
+      name: `tpm`,
+      methodUnderTest: telemetryService.getTpmInfo,
+      expectedResult: fakeData.tpmInfo,
     },
   ];
 

--- a/diagnostics-extension/src/__tests__/utils.spec.ts
+++ b/diagnostics-extension/src/__tests__/utils.spec.ts
@@ -6,12 +6,13 @@
  * @fileoverview Unit tests for src/utils
  */
 
+import { BatteryInfo } from '@common/dpsl';
+import { Response, TelemetryResponse } from '@common/message';
 import {
   generateErrorResponse,
   generateTelemetrySuccessResponse,
 } from '../utils';
-import { Response, TelemetryResponse } from '@common/message';
-import { batteryInfo } from '../services/fake_telemetry.data';
+import * as fakeData from '../services/fake_telemetry.data';
 
 describe('should generate correct response objects', () => {
   it('should generate correct error object', () => {
@@ -25,8 +26,9 @@ describe('should generate correct response objects', () => {
     });
   });
 
-  it('should generate correct telemetry response object', () => {
-    const payload: TelemetryResponse = { info: batteryInfo() };
+  it('should generate correct telemetry response object', async () => {
+    const info: BatteryInfo = await fakeData.getBatteryInfo();
+    const payload: TelemetryResponse = { info };
     const response: Response = generateTelemetrySuccessResponse(payload);
     expect(response).toEqual({
       success: true,

--- a/diagnostics-extension/src/controllers/telemetry.ts
+++ b/diagnostics-extension/src/controllers/telemetry.ts
@@ -28,18 +28,34 @@ const telemetryService = TelemetryServiceProvider.getTelemetryService();
 
 const mapInfoTypeToMethod = (infoType: TelemetryInfoType) => {
   switch (infoType) {
+    case TelemetryInfoType.AUDIO:
+      return telemetryService.getAudioInfo;
     case TelemetryInfoType.BATTERY:
       return telemetryService.getBatteryInfo;
     case TelemetryInfoType.BLOCK_DEVICE:
       return telemetryService.getNonRemovableBlockDevicesInfo;
     case TelemetryInfoType.CPU:
       return telemetryService.getCpuInfo;
+    case TelemetryInfoType.DISPLAY:
+      return telemetryService.getDisplayInfo;
+    case TelemetryInfoType.MARKETING:
+      return telemetryService.getMarketingInfo;
     case TelemetryInfoType.MEMORY:
       return telemetryService.getMemoryInfo;
+    case TelemetryInfoType.NETWORK:
+      return telemetryService.getInternetConnectivityInfo;
+    case TelemetryInfoType.OEM:
+      return telemetryService.getOemData;
+    case TelemetryInfoType.OS_VERSION:
+      return telemetryService.getOsVersionInfo;
+    case TelemetryInfoType.USB:
+      return telemetryService.getUsbBusInfo;
+    case TelemetryInfoType.VPD:
+      return telemetryService.getVpdInfo;
     case TelemetryInfoType.STATEFUL_PARTITION:
       return telemetryService.getStatefulPartitionInfo;
-    case TelemetryInfoType.VPD:
-      return telemetryService.getCachedVpdInfo;
+    case TelemetryInfoType.TPM:
+      return telemetryService.getTpmInfo;
     default:
       return null;
   }

--- a/diagnostics-extension/src/services/fake_telemetry.data.ts
+++ b/diagnostics-extension/src/services/fake_telemetry.data.ts
@@ -7,57 +7,32 @@
  */
 
 import {
+  AudioInfo,
   BatteryInfo,
-  BlockDeviceInfo,
+  NonRemovableBlockDeviceInfoResponse,
   CpuArchitectureEnum,
   CpuInfo,
+  DisplayInputType,
+  DisplayInfo,
+  MarketingInfo,
   MemoryInfo,
+  InternetConnectivityInfo,
   OemData,
-  StatefulPartitionInfo,
+  OsVersionInfo,
+  UsbBusDevices,
   VpdInfo,
+  StatefulPartitionInfo,
+  TpmInfo,
 } from '@common/dpsl';
 
-export const vpdInfo = (): VpdInfo => ({
-  skuNumber: 'sku',
-  serialNumber: 'serial-number',
-  modelName: 'model',
-});
+export const audioInfo: AudioInfo = {
+  outputNodes: [{}],
+  inputNodes: [{}],
+};
+export const getAudioInfo = async (): Promise<AudioInfo> => audioInfo;
 
-export const memoryInfo = (): MemoryInfo => ({
-  totalMemoryKiB: 16270856,
-  freeMemoryKiB: 13067496,
-  availableMemoryKiB: 14810656,
-  pageFaultsSinceLastBoot: '62076622',
-});
-
-export const oemData = (): OemData => ({
-  oemData: 'ABCDEFGHIJKLMN',
-});
-
-export const blockDeviceInfo = (): BlockDeviceInfo => [
-  {
-    path: '/dev/nvme0n1',
-    size: '256060514304',
-    type: 'block:nvme:pci:pci',
-    manufacturerId: 0,
-    name: 'WDC PC SN520 SDAPTUW-256G-1006',
-    serial: '4294967295',
-    bytesReadSinceLastBoot: '5274074112',
-    bytesWrittenSinceLastBoot: '13497171968',
-    readTimeSecondsSinceLastBoot: '40',
-    writeTimeSecondsSinceLastBoot: '1077',
-    ioTimeSecondsSinceLastBoot: '152',
-    discardTimeSecondsSinceLastBoot: '0',
-  },
-];
-
-export const statefulPartitionInfo = (): StatefulPartitionInfo => ({
-  availableSpace: '1340000',
-  totalSpace: '2005000',
-});
-
-export const batteryInfo = (): BatteryInfo => ({
-  cycleCount: '75',
+export const batteryInfo: BatteryInfo = {
+  cycleCount: 75,
   voltageNow: 14,
   vendor: 'google',
   serialNumber: 'test-bat-111',
@@ -70,10 +45,20 @@ export const batteryInfo = (): BatteryInfo => ({
   technology: 'plutonium',
   status: 'good',
   manufactureDate: '2019-07-09T16:59:39.787Z',
-  temperature: '43',
-});
+  temperature: 43,
+};
+export const getBatteryInfo = async (): Promise<BatteryInfo> => batteryInfo;
 
-export const cpuInfo = (): CpuInfo => ({
+export const blockDeviceInfo: NonRemovableBlockDeviceInfoResponse = [
+  {
+    size: 256060514304,
+    type: 'block:nvme:pci:pci',
+    name: 'WDC PC SN520 SDAPTUW-256G-1006',
+  },
+];
+export const getNonRemovableBlockDevicesInfo = async (): Promise<NonRemovableBlockDeviceInfoResponse> => blockDeviceInfo;
+
+export const cpuInfo: CpuInfo = {
   numTotalThreads: 8,
   architecture: CpuArchitectureEnum.x86_64,
   physicalCpus: [
@@ -443,4 +428,72 @@ export const cpuInfo = (): CpuInfo => ({
       ],
     },
   ],
-});
+};
+export const getCpuInfo = async (): Promise<CpuInfo> => cpuInfo;
+
+export const displayInfo: DisplayInfo = {
+  embeddedDisplay: {
+    inputType: DisplayInputType.unknown,
+  },
+  externalDisplays: [
+    {
+      inputType: DisplayInputType.unknown,
+    }
+  ]
+};
+export const getDisplayInfo = async (): Promise<DisplayInfo> => displayInfo;
+
+export const marketingInfo: MarketingInfo = {};
+export const getMarketingInfo = async (): Promise<MarketingInfo> => marketingInfo;
+
+export const memoryInfo: MemoryInfo = {
+  totalMemoryKiB: 16270856,
+  freeMemoryKiB: 13067496,
+  availableMemoryKiB: 14810656,
+  pageFaultsSinceLastBoot: '62076622',
+};
+export const getMemoryInfo = async (): Promise<MemoryInfo> => memoryInfo;
+
+export const networkInfo: InternetConnectivityInfo = {
+  networks: [
+    { ipv6Addresses: ['2001:db8:3333:4444:5555:6666:7777:8888'] },
+  ]
+};
+export const getInternetConnectivityInfo = async (): Promise<InternetConnectivityInfo> => networkInfo;
+
+export const oemInfo: OemData = {
+  oemData: 'ABCDEFGHIJKLMN',
+};
+export const getOemData = async (): Promise<OemData> => oemInfo;
+
+export const osVersionInfo: OsVersionInfo = {};
+export const getOsVersionInfo = async (): Promise<OsVersionInfo> => osVersionInfo;
+
+export const usbInfo: UsbBusDevices = {
+  devices: [
+    {interfaces: [
+      {}
+    ]}
+  ]
+};
+export const getUsbBusInfo = async (): Promise<UsbBusDevices> => usbInfo;
+
+export const vpdInfo: VpdInfo = {
+  skuNumber: 'sku',
+  serialNumber: 'serial-number',
+  modelName: 'model',
+};
+export const getVpdInfo = async (): Promise<VpdInfo> => vpdInfo;
+
+export const statefulPartitionInfo: StatefulPartitionInfo = {
+  availableSpace: 1340000,
+  totalSpace: 2005000,
+};
+export const getStatefulPartitionInfo = async (): Promise<StatefulPartitionInfo> => statefulPartitionInfo;
+
+export const tpmInfo: TpmInfo = {
+  version: {},
+  status: {},
+  dictionaryAttack: {},
+};
+export const getTpmInfo = async (): Promise<TpmInfo> => tpmInfo;

--- a/diagnostics-extension/src/services/telemetry.ts
+++ b/diagnostics-extension/src/services/telemetry.ts
@@ -7,44 +7,43 @@
  */
 
 import {
+  AudioInfo,
   BatteryInfo,
-  BlockDeviceInfo,
+  NonRemovableBlockDeviceInfoResponse,
   CpuInfo,
+  DisplayInfo,
+  MarketingInfo,
   MemoryInfo,
+  InternetConnectivityInfo,
   OemData,
-  StatefulPartitionInfo,
+  OsVersionInfo,
+  UsbBusDevices,
   VpdInfo,
+  StatefulPartitionInfo,
+  TpmInfo,
 } from '@common/dpsl';
-import * as fakeData from './fake_telemetry.data';
+import * as fakeTelemetry from './fake_telemetry.data';
 import { environment } from '../environments/environment';
-import { ResponseErrorInfoMessage } from '@common/message';
 
 /**
  * Abstract class reprensenting the interface of
  * service to fetch system telemetry data
  */
 export abstract class TelemetryService {
-  getBatteryInfo(): Promise<BatteryInfo> {
-    return Promise.reject(ResponseErrorInfoMessage.UnsupportedTelemetryFunction);
-  }
-  getCachedVpdInfo(): Promise<VpdInfo> {
-    return Promise.reject(ResponseErrorInfoMessage.UnsupportedTelemetryFunction);
-  }
-  getCpuInfo(): Promise<CpuInfo> {
-    return Promise.reject(ResponseErrorInfoMessage.UnsupportedTelemetryFunction);
-  }
-  getMemoryInfo(): Promise<MemoryInfo> {
-    return Promise.reject(ResponseErrorInfoMessage.UnsupportedTelemetryFunction);
-  }
-  getNonRemovableBlockDevicesInfo(): Promise<BlockDeviceInfo> {
-    return Promise.reject(ResponseErrorInfoMessage.UnsupportedTelemetryFunction);
-  }
-  getOemData(): Promise<OemData> {
-    return Promise.reject(ResponseErrorInfoMessage.UnsupportedTelemetryFunction);
-  }
-  getStatefulPartitionInfo(): Promise<StatefulPartitionInfo> {
-    return Promise.reject(ResponseErrorInfoMessage.UnsupportedTelemetryFunction);
-  }
+  abstract getAudioInfo(): Promise<AudioInfo>;
+  abstract getBatteryInfo(): Promise<BatteryInfo>;
+  abstract getNonRemovableBlockDevicesInfo(): Promise<NonRemovableBlockDeviceInfoResponse>
+  abstract getCpuInfo(): Promise<CpuInfo>;
+  abstract getDisplayInfo(): Promise<DisplayInfo>;
+  abstract getMarketingInfo(): Promise<MarketingInfo>;
+  abstract getMemoryInfo(): Promise<MemoryInfo>;
+  abstract getInternetConnectivityInfo(): Promise<InternetConnectivityInfo>;
+  abstract getOemData(): Promise<OemData>
+  abstract getOsVersionInfo(): Promise<OsVersionInfo>;
+  abstract getUsbBusInfo(): Promise<UsbBusDevices>;
+  abstract getVpdInfo(): Promise<VpdInfo>;
+  abstract getStatefulPartitionInfo(): Promise<StatefulPartitionInfo>;
+  abstract getTpmInfo(): Promise<TpmInfo>;
 }
 
 /**
@@ -52,26 +51,47 @@ export abstract class TelemetryService {
  * @extends TelemetryService
  */
 export class TelemetryServiceImpl extends TelemetryService {
+  async getAudioInfo(): Promise<AudioInfo> {
+    return (chrome as any).os.telemetry.getAudioInfo();
+  }
   async getBatteryInfo(): Promise<BatteryInfo> {
     return (chrome as any).os.telemetry.getBatteryInfo();
   }
-  async getCachedVpdInfo(): Promise<VpdInfo> {
-    return (chrome as any).os.telemetry.getVpdInfo();
+  async getNonRemovableBlockDevicesInfo(): Promise<NonRemovableBlockDeviceInfoResponse> {
+    return (chrome as any).os.telemetry.getNonRemovableBlockDevicesInfo();
   }
   async getCpuInfo(): Promise<CpuInfo> {
     return (chrome as any).os.telemetry.getCpuInfo();
   }
+  async getDisplayInfo(): Promise<DisplayInfo> {
+    return (chrome as any).os.telemetry.getDisplayInfo();
+  }
+  async getMarketingInfo(): Promise<MarketingInfo> {
+    return (chrome as any).os.telemetry.getMarketingInfo();
+  }
   async getMemoryInfo(): Promise<MemoryInfo> {
     return (chrome as any).os.telemetry.getMemoryInfo();
   }
-  async getNonRemovableBlockDevicesInfo(): Promise<BlockDeviceInfo> {
-    return (chrome as any).os.telemetry.getNonRemovableBlockDevicesInfo();
+  async getInternetConnectivityInfo(): Promise<InternetConnectivityInfo> {
+    return (chrome as any).os.telemetry.getInternetConnectivityInfo();
   }
   async getOemData(): Promise<OemData> {
     return (chrome as any).os.telemetry.getOemData();
   }
+  async getOsVersionInfo(): Promise<OsVersionInfo> {
+    return (chrome as any).os.telemetry.getOsVersionInfo();
+  }
+  async getUsbBusInfo(): Promise<UsbBusDevices> {
+    return (chrome as any).os.telemetry.getUsbBusInfo();
+  }
+  async getVpdInfo(): Promise<VpdInfo> {
+    return (chrome as any).os.telemetry.getVpdInfo();
+  }
   async getStatefulPartitionInfo(): Promise<StatefulPartitionInfo> {
     return (chrome as any).os.telemetry.getStatefulPartitionInfo();
+  }
+  async getTpmInfo(): Promise<TpmInfo> {
+    return (chrome as any).os.telemetry.getTpmInfo();
   }
 }
 
@@ -80,26 +100,47 @@ export class TelemetryServiceImpl extends TelemetryService {
  * @extends TelemetryService
  */
 export class FakeTelemetryService extends TelemetryService {
-  async getBatteryInfo(): Promise<BatteryInfo> {
-    return fakeData.batteryInfo();
+  async getAudioInfo(): Promise<AudioInfo> {
+    return fakeTelemetry.getAudioInfo();
   }
-  async getCachedVpdInfo(): Promise<VpdInfo> {
-    return fakeData.vpdInfo();
+  async getBatteryInfo(): Promise<BatteryInfo> {
+    return fakeTelemetry.getBatteryInfo();
+  }
+  async getNonRemovableBlockDevicesInfo(): Promise<NonRemovableBlockDeviceInfoResponse> {
+    return fakeTelemetry.getNonRemovableBlockDevicesInfo();
   }
   async getCpuInfo(): Promise<CpuInfo> {
-    return fakeData.cpuInfo();
+    return fakeTelemetry.getCpuInfo();
+  }
+  async getDisplayInfo(): Promise<DisplayInfo> {
+    return fakeTelemetry.getDisplayInfo();
+  }
+  async getMarketingInfo(): Promise<MarketingInfo> {
+    return fakeTelemetry.getMarketingInfo();
   }
   async getMemoryInfo(): Promise<MemoryInfo> {
-    return fakeData.memoryInfo();
+    return fakeTelemetry.getMemoryInfo();
   }
-  async getNonRemovableBlockDevicesInfo(): Promise<BlockDeviceInfo> {
-    return fakeData.blockDeviceInfo();
+  async getInternetConnectivityInfo(): Promise<InternetConnectivityInfo> {
+    return fakeTelemetry.getInternetConnectivityInfo();
   }
   async getOemData(): Promise<OemData> {
-    return fakeData.oemData();
+    return fakeTelemetry.getOemData();
+  }
+  async getOsVersionInfo(): Promise<OsVersionInfo> {
+    return fakeTelemetry.getOsVersionInfo();
+  }
+  async getUsbBusInfo(): Promise<UsbBusDevices> {
+    return fakeTelemetry.getUsbBusInfo();
+  }
+  async getVpdInfo(): Promise<VpdInfo> {
+    return fakeTelemetry.getVpdInfo();
   }
   async getStatefulPartitionInfo(): Promise<StatefulPartitionInfo> {
-    return fakeData.statefulPartitionInfo();
+    return fakeTelemetry.getStatefulPartitionInfo();
+  }
+  async getTpmInfo(): Promise<TpmInfo> {
+    return fakeTelemetry.getTpmInfo();
   }
 }
 


### PR DESCRIPTION
[Extension]
- Implement the service for fetching 'AudioInfo', 'DisplayInfo', 'MarketingInfo', 'InternetConnectivityInfo', 'OsVersionInfo', 'UsbBusDevices', 'VpdInfo', and 'TpmInfo'
- Create the fake service for them in file 'fake_telemetry.data.ts'
- Update the existing test cases

[Other]
- Add and update telemetry-related definitions in file 'dpsl.ts'
- Add the newly supported telemetry types to the 'TelemetryInfoType' in file 'message.ts'

BUG: b/296518192