### PR TITLE
[Extension] Remove dependency on cros-dpsl-js

### DIFF
--- a/diagnostics-extension/package-lock.json
+++ b/diagnostics-extension/package-lock.json
@@ -13,7 +13,6 @@
         "@types/jest": "^27.5.2",
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
-        "cros-dpsl-js": "^1.3.1",
         "eslint": "^7.32.0",
         "jest": "^27.5.1",
         "ts-jest": "^27.1.5",
@@ -2403,12 +2402,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "dev": true
-    },
-    "node_modules/cros-dpsl-js": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/cros-dpsl-js/-/cros-dpsl-js-1.3.6.tgz",
-      "integrity": "sha512-PHwXkRfoEUXb4qYjXFHxOe2sm/gSu0qdTTqwgU18+AQo8pXBbLfCZz3v+I6KEr5JBgK2y7s9XJqyab6v+5Kd8w==",
       "dev": true
     },
     "node_modules/cross-spawn": {

--- a/diagnostics-extension/package.json
+++ b/diagnostics-extension/package.json
@@ -20,7 +20,6 @@
   "_devDependencies": {
     "@typescript-eslint/eslint-plugin": "TypeScript plugin for eslint",
     "@typescript-eslint/parser": "^Typescript parser for eslint",
-    "cros-dpsl-js": "Diagnostics support library for Chrome OS",
     "eslint": "eslint for lint configurations",
     "jest": "Testing library",
     "ts-jest": "TypeScript support for Jest",
@@ -34,7 +33,6 @@
     "@types/jest": "^27.5.2",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
-    "cros-dpsl-js": "^1.3.1",
     "eslint": "^7.32.0",
     "jest": "^27.5.1",
     "ts-jest": "^27.1.5",


### PR DESCRIPTION
The DPSL function calls were deprecated by a previously merged PR: "[Extension] Extend Telemetry service #44". And the dependency on the library 'cros-dpsl-js' is removed from the 'package.json' file and the 'package-lock.json' file.

BUG: b/295125739