### PR TITLE
Logging

### DIFF
--- a/diagnostics-app/src/app/app.module.ts
+++ b/diagnostics-app/src/app/app.module.ts
@@ -19,6 +19,7 @@ import {AppRoutingModule} from './app-routing.module';
 import {AppComponent} from './app.component';
 import {CoreModule} from './core/core.module';
 import {EventsService} from './core/services/events.service';
+import {LoggingService} from './core/services/logging.service';
 import {RoutineV2Service} from './core/services/routine-v2.service';
 import {SharedModule} from './shared/shared.module';
 
@@ -67,6 +68,7 @@ function initializeRoutineV2ServiceFactory(
       provide: LocationStrategy,
       useClass: HashLocationStrategy,
     },
+    LoggingService,
   ],
   bootstrap: [AppComponent],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],

--- a/diagnostics-app/src/app/core/services/logging.service.spec.ts
+++ b/diagnostics-app/src/app/core/services/logging.service.spec.ts
@@ -1,0 +1,16 @@
+import {TestBed} from '@angular/core/testing';
+
+import {LoggingService} from './logging.service';
+
+describe('LoggingService', () => {
+  let service: LoggingService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(LoggingService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/diagnostics-app/src/app/core/services/logging.service.ts
+++ b/diagnostics-app/src/app/core/services/logging.service.ts
@@ -1,0 +1,46 @@
+import {Injectable} from '@angular/core';
+import {BehaviorSubject, Observable} from 'rxjs';
+
+enum LogLevel {
+  Debug = 'DEBUG',
+  Info = 'INFO',
+  Warn = 'WARN',
+  Error = 'ERROR',
+}
+
+export interface LogEntry {
+  timestamp: Date;
+  level: LogLevel;
+  message: string;
+}
+
+@Injectable({providedIn: 'root'})
+export class LoggingService {
+  private logs$ = new BehaviorSubject<LogEntry[]>([]);
+
+  constructor() {}
+
+  log(level: LogLevel, message: string) {
+    this.logs$.next([
+      ...this.logs$.value,
+      {timestamp: new Date(), level, message},
+    ]);
+  }
+
+  debug(message: string) {
+    this.log(LogLevel.Debug, message);
+  }
+  info(message: string) {
+    this.log(LogLevel.Info, message);
+  }
+  warn(message: string) {
+    this.log(LogLevel.Warn, message);
+  }
+  error(message: string) {
+    this.log(LogLevel.Error, message);
+  }
+
+  getLogs(): Observable<LogEntry[]> {
+    return this.logs$.asObservable();
+  }
+}

--- a/diagnostics-app/src/app/rma/layout/content-layout/content-layout.component.css
+++ b/diagnostics-app/src/app/rma/layout/content-layout/content-layout.component.css
@@ -4,7 +4,7 @@
  * found in the LICENSE file.
  */
 
- .sidenav-container {
+.sidenav-container {
   height: 100%;
 }
 
@@ -50,16 +50,22 @@ mat-sidenav.mat-drawer-side {
 .app-content-container {
   display: flex;
   flex-direction: column;
-  flex: 1 1 auto;
+  flex: 1 1 auto; /* Allow app-content-container to fill remaining space */
+  overflow: auto; /* Prevent any scrolling in app-content-container */
 }
 
 .test-container {
+  box-sizing: border-box; /* Key Change */
   padding: 1rem 1rem;
-  flex: 1 1 60%; /* Take 60% of the space */
+  flex: 0 0 60%; /* Take 60% of the space */
   overflow: auto; /* Add scrolling if needed */
+  border-bottom: 5px solid var(--app-header-border-bottom-color);
 }
 
 .log-container {
+  background-color: var(--app-log-viewer-background);
+  box-sizing: border-box; /* Key Change */
   padding: 1rem 1rem;
-  flex: 1 1 40%; /* Take 40% of the space */
+  flex: 0 0 40%; /* Take 40% of the space */
+  overflow: auto; /* Add scrolling if needed */
 }

--- a/diagnostics-app/src/app/rma/layout/content-layout/content-layout.component.html
+++ b/diagnostics-app/src/app/rma/layout/content-layout/content-layout.component.html
@@ -22,7 +22,7 @@
         test container
       </div>
       <div class="log-container">
-        log container
+        <app-log-viewer />
       </div>
     </div>
   </mat-sidenav-content>

--- a/diagnostics-app/src/app/rma/log-viewer/log-viewer.component.html
+++ b/diagnostics-app/src/app/rma/log-viewer/log-viewer.component.html
@@ -1,0 +1,3 @@
+<div *ngFor="let log of logs$ | async">
+  [<span class="{{log.level}}">{{log.level}}</span>] {{ formatTimestamp(log.timestamp) }}: {{log.message}}
+</div>

--- a/diagnostics-app/src/app/rma/log-viewer/log-viewer.component.spec.ts
+++ b/diagnostics-app/src/app/rma/log-viewer/log-viewer.component.spec.ts
@@ -1,0 +1,21 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {LogViewerComponent} from './log-viewer.component';
+
+describe('LogViewerComponent', () => {
+  let component: LogViewerComponent;
+  let fixture: ComponentFixture<LogViewerComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [LogViewerComponent],
+    });
+    fixture = TestBed.createComponent(LogViewerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/diagnostics-app/src/app/rma/log-viewer/log-viewer.component.ts
+++ b/diagnostics-app/src/app/rma/log-viewer/log-viewer.component.ts
@@ -1,0 +1,19 @@
+import {Component} from '@angular/core';
+import {Observable} from 'rxjs';
+
+import {LogEntry, LoggingService} from 'app/core/services/logging.service';
+
+@Component({
+  selector: 'app-log-viewer',
+  templateUrl: './log-viewer.component.html',
+  styleUrls: ['./log-viewer.component.css'],
+})
+export class LogViewerComponent {
+  logs$: Observable<LogEntry[]> = this.loggingService.getLogs();
+
+  formatTimestamp(timestamp: Date): string {
+    return timestamp.toISOString();
+  }
+
+  constructor(private loggingService: LoggingService) {}
+}

--- a/diagnostics-app/src/app/rma/rma.module.ts
+++ b/diagnostics-app/src/app/rma/rma.module.ts
@@ -2,10 +2,11 @@ import {NgModule} from '@angular/core';
 
 import {SharedModule} from '@shared/shared.module';
 import {ContentLayoutComponent} from './layout/content-layout/content-layout.component';
+import {LogViewerComponent} from './log-viewer/log-viewer.component';
 import {RmaRoutingModule} from './rma-routing.module';
 
 @NgModule({
-  declarations: [ContentLayoutComponent],
+  declarations: [ContentLayoutComponent, LogViewerComponent],
   imports: [RmaRoutingModule, SharedModule],
   exports: [ContentLayoutComponent],
 })

--- a/diagnostics-app/src/app/support-assist/events/events-card/events-card.component.css
+++ b/diagnostics-app/src/app/support-assist/events/events-card/events-card.component.css
@@ -61,15 +61,3 @@
   align-items: center;
   margin-top: 1rem;
 }
-
-::-webkit-scrollbar {
-  width: 4px;
-  overflow-y: scroll;
-  background: grey;
-  box-shadow: inset 0 0 4px #707070;
-}
-
-::-webkit-scrollbar-thumb {
-  background: black;
-  border-radius: 10px;
-}

--- a/diagnostics-app/src/app/support-assist/telemetry/telemetry-card/telemetry-card.component.css
+++ b/diagnostics-app/src/app/support-assist/telemetry/telemetry-card/telemetry-card.component.css
@@ -26,18 +26,6 @@
   padding: 10px;
 }
 
-::-webkit-scrollbar {
-  width: 4px;
-  overflow-y: scroll;
-  background: grey;
-  box-shadow: inset 0 0 4px #707070;
-}
-
-::-webkit-scrollbar-thumb {
-  background: black;
-  border-radius: 10px;
-}
-
 .error-message {
   color: var(--app-error-message-color);
   border-radius: 5px;

--- a/diagnostics-app/src/styles.css
+++ b/diagnostics-app/src/styles.css
@@ -13,3 +13,15 @@ body {
   margin: 0;
   font-family: Roboto, "Helvetica Neue", sans-serif;
 }
+
+::-webkit-scrollbar {
+  width: 10px;
+  overflow-y: scroll;
+  background: grey;
+  box-shadow: inset 0 0 4px #707070;
+}
+
+::-webkit-scrollbar-thumb {
+  background: black;
+  border-radius: 10px;
+}

--- a/diagnostics-app/src/styles/theme.css
+++ b/diagnostics-app/src/styles/theme.css
@@ -41,7 +41,8 @@
   --color-black: #000;
   --color-dark: #121212;
   --color-dark-grey: #1c1c1c;
-  --color-light-grey: #292929;
+  --color-medium-grey: #252525;
+  --color-light-grey: #303030;
   --color-lighter-grey: #cbcaca;
   --color-darker-white: #989898;
   --color-dark-white: #e3e3e3;
@@ -52,7 +53,7 @@
 
   --color-blue: rgb(76, 139, 245);
 
-  --app-header-background: var(--color-light-grey);
+  --app-header-background: var(--color-medium-grey);
   --app-header-border-bottom-color: var(--color-dark-grey);
   --app-header-color: var(--color-white);
 
@@ -70,6 +71,9 @@
   --app-dashboard-card-background: var(--color-dark-grey);
   --app-dashboard-card-color: var(--color-white);
   --app-dashboard-card-border-color: #333;
+
+  --app-log-viewer-background: var(--color-medium-grey);
+  --app-log-viewer-color: var(--color-white);
 
   --app-error-message-color: var(--color-yellow);
 }


### PR DESCRIPTION
Add logging service in preparation for RMA mode. This should work the same way as in factory toolkit where failed tests will log their output.

A note on support assist:
Since there is no log-viewing capability within support-assist mode other than through dev-tools, we don't anticipate support-assist components to log through the service. Support assist will continue to use console log/error, and b/317946517 tracks separately to show error at the UI level directly.

The current design also means that logs are shared between support-assist mode and RMA mode. In practice, once released, we anticipate OEMs to build only one of the two modes without the ability to toggle. Therefore log-sharing should not be a problem.