### PR TITLE
[Extension] Create port service and control service worker lifetime

### DIFF
--- a/diagnostics-extension/src/controllers/events.controller.ts
+++ b/diagnostics-extension/src/controllers/events.controller.ts
@@ -68,10 +68,6 @@ export async function registerEventHandlers() {
     });
 }
 
-export async function onEventPortConnect(port: chrome.runtime.Port) {
-  eventsService.registerPort(port);
-}
-
 export async function handleEvents(
   req: Request,
   res: (data: Response) => void,

--- a/diagnostics-extension/src/controllers/routine-v2.controller.ts
+++ b/diagnostics-extension/src/controllers/routine-v2.controller.ts
@@ -25,10 +25,6 @@ export function registerRoutineV2EventHandlers(): void {
   routineV2Service.registerRoutineV2EventHandlers();
 }
 
-export async function onRoutineV2PortConnect(port: chrome.runtime.Port) {
-  routineV2Service.registerPort(port);
-}
-
 export async function handleRoutineV2(
   req: Request,
   res: (data: Response) => void,

--- a/diagnostics-extension/src/services/fake-events.service.ts
+++ b/diagnostics-extension/src/services/fake-events.service.ts
@@ -9,14 +9,14 @@
 // Fake data may not use certain parameter variables.
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import {Response} from '../common/message';
+import {PortName, Response} from '../common/message';
 import {
   EventCategory,
   EventSupportStatus,
   EventSupportStatusInfo,
 } from '../common/telemetry-extension-types';
+import {PortService} from './port.service';
 
-let eventPort: chrome.runtime.Port;
 const categoryToIntervalId: Map<
   EventCategory,
   ReturnType<typeof setTimeout>
@@ -31,16 +31,13 @@ export async function registerEventHandlers(): Promise<Response> {
   return {success: true};
 }
 
-export function registerPort(port: chrome.runtime.Port): void {
-  eventPort = port;
-  return;
-}
-
 function notifyPort(type: EventCategory, message: object): void {
-  if (!eventPort) {
+  const port = PortService.getInstance().getPort(PortName.EVENTS_PORT);
+  if (!port) {
+    console.error('port not connected');
     return;
   }
-  eventPort.postMessage({
+  port.postMessage({
     type: type,
     info: message,
   });

--- a/diagnostics-extension/src/services/fake-routine-v2.service.ts
+++ b/diagnostics-extension/src/services/fake-routine-v2.service.ts
@@ -16,6 +16,7 @@ import {
   VolumeButtonRoutineArgument,
 } from '../common/config/support-assist';
 import {
+  PortName,
   RoutineV2Argument,
   RoutineV2Category,
   RoutineV2EventCategory,
@@ -34,8 +35,7 @@ import {
   RoutineWaitingReason,
   StartRoutineRequest,
 } from '../common/telemetry-extension-types';
-
-let routineV2Port: chrome.runtime.Port;
+import {PortService} from './port.service';
 
 // Fake data to return result of running each routine.
 // Maps compare reference of objects. Thus we use the JSON stringify notation to
@@ -191,19 +191,16 @@ export function registerEventHandlers(): void {
   return;
 }
 
-export function registerPort(port: chrome.runtime.Port): void {
-  routineV2Port = port;
-  return;
-}
-
 function notifyPort(
   eventCategory: RoutineV2EventCategory,
   event: RoutineV2EventUnion,
 ): void {
-  if (!routineV2Port) {
+  const port = PortService.getInstance().getPort(PortName.ROUTINE_V2_PORT);
+  if (!port) {
+    console.error('port not connected');
     return;
   }
-  routineV2Port.postMessage({
+  port.postMessage({
     eventCategory: eventCategory,
     event: event,
   });

--- a/diagnostics-extension/src/services/port.service.ts
+++ b/diagnostics-extension/src/services/port.service.ts
@@ -1,0 +1,43 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+
+export class PortService {
+  private static instance: PortService | null = null;
+
+  private ports: Map<string, chrome.runtime.Port> = new Map();
+
+  private heartbeatInterval: null | ReturnType<typeof setInterval> = null;
+
+  constructor() {}
+
+  startHeartbeat() {
+    this.heartbeatInterval = setInterval(() => {
+      console.log('heartbeat');
+      chrome.runtime.getPlatformInfo(() => {});
+    }, 25 * 1000);
+  }
+
+  public static getInstance(): PortService {
+    if (PortService.instance === null) {
+      PortService.instance = new PortService();
+    }
+    return PortService.instance;
+  }
+
+  registerPort(port: chrome.runtime.Port) {
+    if (this.heartbeatInterval === null) {
+      this.startHeartbeat();
+    }
+    this.ports.set(port.name, port);
+    port.onDisconnect.addListener((port) => {
+      this.ports.delete(port.name);
+      if (this.ports.size === 0 && this.heartbeatInterval !== null) {
+        clearInterval(this.heartbeatInterval);
+        this.heartbeatInterval = null;
+      }
+    });
+  }
+
+  getPort(portName: string): chrome.runtime.Port | undefined {
+    return this.ports.get(portName);
+  }
+}

--- a/diagnostics-extension/src/sw.ts
+++ b/diagnostics-extension/src/sw.ts
@@ -6,24 +6,18 @@
  * @fileoverview Service worker script
  */
 
-import {
-  PortName,
-  Request,
-  RequestType,
-  ResponseErrorInfoMessage,
-} from './common/message';
+import {Request, RequestType, ResponseErrorInfoMessage} from './common/message';
 import {handleDiagnostics} from './controllers/diagnostics.controller';
 import {
   handleEvents,
-  onEventPortConnect,
   registerEventHandlers,
 } from './controllers/events.controller';
 import {
   handleRoutineV2,
-  onRoutineV2PortConnect,
   registerRoutineV2EventHandlers,
 } from './controllers/routine-v2.controller';
 import {handleTelemetry} from './controllers/telemetry.controller';
+import {PortService} from './services/port.service';
 import {generateErrorResponse} from './utils';
 
 // Event handlers in service workers need to be declared in the global scope.
@@ -37,16 +31,7 @@ chrome.runtime.onInstalled.addListener(
 );
 
 chrome.runtime.onConnectExternal.addListener((port: chrome.runtime.Port) => {
-  switch (port.name) {
-    case PortName.EVENTS_PORT:
-      onEventPortConnect(port);
-      return;
-    case PortName.ROUTINE_V2_PORT:
-      onRoutineV2PortConnect(port);
-      return;
-    default:
-      console.error(ResponseErrorInfoMessage.INVALID_PORT_NAME);
-  }
+  PortService.getInstance().registerPort(port);
 });
 
 chrome.runtime.onMessageExternal.addListener((req: Request, sender, res) => {


### PR DESCRIPTION
Create a service that is dedicated to storing port information and controlling service worker lifetime. The service worker should remain alive while any port is still active, otherwise it may be shut down.