### PR TITLE
[Routine] Introduce network bandwidth routine

### DIFF
--- a/diagnostics-app/src/app/rma/test-viewer/routine-v2-test/routine-v2-test.component.ts
+++ b/diagnostics-app/src/app/rma/test-viewer/routine-v2-test/routine-v2-test.component.ts
@@ -150,6 +150,9 @@ export class RoutineV2TestComponent implements BaseTestComponent {
         if (routineRunningInfo.percentage) {
           this.percentage = routineRunningInfo.percentage;
         }
+        if (routineRunningInfo.info) {
+          this.output = routineRunningInfo.info;
+        }
         break;
       }
       case RoutineV2EventCategory.WAITING: {

--- a/diagnostics-app/src/app/support-assist/routine-v2/routine-v2-card/routine-v2-card.component.ts
+++ b/diagnostics-app/src/app/support-assist/routine-v2/routine-v2-card/routine-v2-card.component.ts
@@ -156,6 +156,9 @@ export class RoutineV2CardComponent implements OnInit, OnDestroy {
         if (routineRunningInfo.percentage) {
           this.percentage = routineRunningInfo.percentage;
         }
+        if (routineRunningInfo.info) {
+          this.output = routineRunningInfo.info;
+        }
         break;
       }
       case RoutineV2EventCategory.WAITING: {

--- a/diagnostics-app/src/common/config/support-assist.ts
+++ b/diagnostics-app/src/common/config/support-assist.ts
@@ -8,6 +8,7 @@ import {RoutineType} from '../telemetry-extension-types/legacy-diagnostics';
 import {
   CreateFanRoutineArguments,
   CreateMemoryRoutineArguments,
+  CreateNetworkBandwidthRoutineArguments,
   CreateRoutineArgumentsUnion,
   CreateVolumeButtonRoutineArguments,
   VolumeButtonType,
@@ -87,6 +88,8 @@ export const FanRoutineArgument: CreateFanRoutineArguments = {};
 export const MemoryRoutineArgument: CreateMemoryRoutineArguments = {
   maxTestingMemKib: 10000,
 };
+export const NetworkBandwidthRoutineArgument: CreateNetworkBandwidthRoutineArguments =
+  {};
 /* eslint-disable camelcase*/
 export const VolumeButtonRoutineArgument: CreateVolumeButtonRoutineArguments = {
   buttonType: VolumeButtonType.volume_up,
@@ -97,6 +100,9 @@ export const VolumeButtonRoutineArgument: CreateVolumeButtonRoutineArguments = {
 export const VISIBLE_ROUTINE_V2_CARDS: CreateRoutineArgumentsUnion[] = [
   {[RoutineV2Category.FAN]: FanRoutineArgument},
   {[RoutineV2Category.MEMORY]: MemoryRoutineArgument},
+  {
+    [RoutineV2Category.NETWORK_BANDWIDTH]: NetworkBandwidthRoutineArgument,
+  },
   {
     [RoutineV2Category.VOLUME_BUTTON]: VolumeButtonRoutineArgument,
   },

--- a/diagnostics-app/src/common/message.ts
+++ b/diagnostics-app/src/common/message.ts
@@ -274,6 +274,7 @@ export enum RoutineV2Action {
 export enum RoutineV2Category {
   FAN = 'fan',
   MEMORY = 'memory',
+  NETWORK_BANDWIDTH = 'networkBandwidth',
   VOLUME_BUTTON = 'volumeButton',
 }
 

--- a/diagnostics-app/src/common/telemetry-extension-types/routines.ts
+++ b/diagnostics-app/src/common/telemetry-extension-types/routines.ts
@@ -11,9 +11,27 @@ export interface RoutineInitializedInfo {
   uuid?: string;
 }
 
+export enum NetworkBandwidthRoutineRunningInfoType {
+  download = 'download',
+  upload = 'upload',
+}
+
+export interface NetworkBandwidthRoutineRunningInfo {
+  // The type of test that routine is running.
+  type: NetworkBandwidthRoutineRunningInfoType;
+  // The current network speed in kbit/s.
+  speedKbps: number;
+}
+
+// This is a union type. Exactly one field should be set.
+export interface RoutineRunningInfoUnion {
+  networkBandwidth?: NetworkBandwidthRoutineRunningInfo;
+}
+
 export interface RoutineRunningInfo {
   uuid?: string;
   percentage?: number;
+  info?: RoutineRunningInfoUnion;
 }
 
 export enum RoutineWaitingReason {
@@ -158,6 +176,16 @@ export interface FanRoutineFinishedDetail {
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface CreateFanRoutineArguments {}
 
+export interface NetworkBandwidthRoutineFinishedDetail {
+  // Average download speed in kbit/s.
+  downloadSpeedKbps: number;
+  // Average upload speed in kbit/s.
+  uploadSpeedKbps: number;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface CreateNetworkBandwidthRoutineArguments {}
+
 export interface CreateRoutineResponse {
   uuid?: string;
 }
@@ -184,12 +212,14 @@ export interface CreateRoutineArgumentsUnion {
   memory?: CreateMemoryRoutineArguments;
   volumeButton?: CreateVolumeButtonRoutineArguments;
   fan?: CreateFanRoutineArguments;
+  networkBandwidth?: CreateNetworkBandwidthRoutineArguments;
 }
 
 // This is a union type. Exactly one field should be set.
 export interface RoutineFinishedDetailUnion {
   memory?: MemoryRoutineFinishedDetail;
   fan?: FanRoutineFinishedDetail;
+  networkBandwidth?: NetworkBandwidthRoutineFinishedDetail;
 }
 
 export interface RoutineFinishedInfo {

--- a/diagnostics-extension/src/services/fake-routine-v2.service.ts
+++ b/diagnostics-extension/src/services/fake-routine-v2.service.ts
@@ -13,6 +13,7 @@ import {v4 as uuidv4} from 'uuid';
 import {
   FanRoutineArgument,
   MemoryRoutineArgument,
+  NetworkBandwidthRoutineArgument,
   VolumeButtonRoutineArgument,
 } from '../common/config/support-assist';
 import {
@@ -73,6 +74,22 @@ const fakeRoutineData = new Map<string, RoutineFinishedInfo>([
             passedItems: [MemtesterTestItemEnum.stuck_address],
             failedItems: [],
           },
+        },
+      },
+    },
+  ],
+  // Fake network bandwidth routine data.
+  [
+    JSON.stringify({
+      [RoutineV2Category.NETWORK_BANDWIDTH]: NetworkBandwidthRoutineArgument,
+    }),
+    {
+      uuid: '',
+      hasPassed: true,
+      detail: {
+        [RoutineV2Category.NETWORK_BANDWIDTH]: {
+          downloadSpeedKbps: 20000.0,
+          uploadSpeedKbps: 20000.0,
         },
       },
     },


### PR DESCRIPTION
Support network bandwidth routine in support assistant by updating configs and interfaces.
Also update to display routine running info.

BUG=b/338910198
TEST=npm ci && npm run build_pwa
TEST=Deploy on DUT and test new routine 